### PR TITLE
Remove unused and unread variables reported by cppcheck

### DIFF
--- a/c/drivewire.c
+++ b/c/drivewire.c
@@ -117,7 +117,6 @@ int loadPreferences(struct dwTransferData *datapack)
 int savePreferences(struct dwTransferData *datapack)
 {
 	FILE	*pf;
-	char	buffer[81];
 	int	i;
 
 
@@ -192,7 +191,6 @@ void logHeader(void)
 
 int main(int argc, char **argv)
 {
-    int i;
     pthread_t thread_id;
     int quitter = 0;
 

--- a/c/dwprotocol.c
+++ b/c/dwprotocol.c
@@ -8,9 +8,6 @@ void *DriveWireProcessor(void *data)
 
 	while (comRead(dp, &(dp->lastOpcode), 1) > 0)
 	{
-		fd_set	rfds;
-		struct timeval	tv;
-		char *timeString = NULL;
 
 		{
 

--- a/c/dwwin.c
+++ b/c/dwwin.c
@@ -7,8 +7,6 @@ void WinInit(void)
         return;
     }
     
-	int y = 1;
-
 	initscr();
 	clear();
 	window0 = newwin(24, 80, 0, 0);


### PR DESCRIPTION
I found these unused variables by using the cppcheck tool.