### PR TITLE
Cleanup compiler size warnings

### DIFF
--- a/c/drivewire.c
+++ b/c/drivewire.c
@@ -81,7 +81,7 @@ void closeDSK(struct dwTransferData *dp, int which)
 int loadPreferences(struct dwTransferData *datapack)
 {
 	FILE	*pf;
-	char	buffer[81];
+	char	buffer[128];
 	int	i;
 	char	*p;
 

--- a/c/drivewire.h
+++ b/c/drivewire.h
@@ -76,7 +76,7 @@ struct dwTransferData
 	unsigned char	lastError;
 	FILE	*prtfp;
 	unsigned char	lastChar;
-	char	prtcmd[80];
+	char	prtcmd[128];
 };
 
 

--- a/c/dwprotocol.c
+++ b/c/dwprotocol.c
@@ -433,7 +433,7 @@ void DoOP_PRINT(struct dwTransferData *dp)
 
 void DoOP_PRINTFLUSH(struct dwTransferData *dp)
 {
-	char buff[128];
+	char buff[256];
 
 	fclose(dp->prtfp);
 	sprintf(buff, "cat drivewire.prt %s\n", dp->prtcmd);

--- a/c/dwwin.c
+++ b/c/dwwin.c
@@ -253,7 +253,7 @@ void WinUpdate(WINDOW *window, struct dwTransferData *dp)
 	wclrtoeol(window);
 
 	wmove(window, y++, x); wclrtoeol(window);
-	wprintw(window, dp->prtcmd);
+	wprintw(window, "%s", dp->prtcmd);
 
 	wmove(window, y++, x); wclrtoeol(window);
 


### PR DESCRIPTION
While building the C implementation of DriveWire, got these messages during `make` build.  Just a few variable sizes that had to be tweaked to get everything to compile without any warnings.

```
$ make
cc -g -DLINUX   -c -o drivewire.o drivewire.c
drivewire.c: In function ‘loadPreferences’:
drivewire.c:106:9: warning: ‘fgets’ writing 128 bytes into a region of size 81 overflows the destination [-Wstringop-overflow=]
  106 |         fgets(buffer, 128, pf);
      |         ^~~~~~~~~~~~~~~~~~~~~~
drivewire.c:84:17: note: destination object ‘buffer’ of size 81
   84 |         char    buffer[81];
      |                 ^~~~~~
In file included from drivewire.h:7,
                 from drivewire.c:2:
/usr/include/stdio.h:658:14: note: in a call to function ‘fgets’ declared with attribute ‘access (write_only, 1, 2)’
  658 | extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      |              ^~~~~
drivewire.c:108:9: warning: ‘fgets’ writing 128 bytes into a region of size 81 overflows the destination [-Wstringop-overflow=]
  108 |         fgets(buffer, 128, pf);
      |         ^~~~~~~~~~~~~~~~~~~~~~
drivewire.c:84:17: note: destination object ‘buffer’ of size 81
   84 |         char    buffer[81];
      |                 ^~~~~~
/usr/include/stdio.h:658:14: note: in a call to function ‘fgets’ declared with attribute ‘access (write_only, 1, 2)’
  658 | extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      |              ^~~~~
drivewire.c:111:9: warning: ‘fgets’ writing 128 bytes into a region of size 80 overflows the destination [-Wstringop-overflow=]
  111 |         fgets(datapack->prtcmd, 128, pf);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivewire.h:79:17: note: destination object ‘prtcmd’ of size 80
   79 |         char    prtcmd[80];
      |                 ^~~~~~
/usr/include/stdio.h:658:14: note: in a call to function ‘fgets’ declared with attribute ‘access (write_only, 1, 2)’
  658 | extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      |              ^~~~~
cc -g -DLINUX   -c -o dwprotocol.o dwprotocol.c
cc -g -DLINUX   -c -o dwwin.o dwwin.c
dwwin.c: In function ‘WinUpdate’:
dwwin.c:256:27: warning: format not a string literal and no format arguments [-Wformat-security]
  256 |         wprintw(window, dp->prtcmd);
      |                         ~~^~~~~~~~
cc   drivewire.o dwprotocol.o dwwin.o  -lcurses -lpthread -g -o drivewire

```