### PR TITLE
Fix RFM protocol to match rfm.asm wire format

### DIFF
--- a/swift/DriveWire.xcodeproj/xcshareddata/xcschemes/drivewire-cli.xcscheme
+++ b/swift/DriveWire.xcodeproj/xcshareddata/xcschemes/drivewire-cli.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2700"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "68A8420C2AD329B6009BE6D3"
+               BuildableName = "drivewire-cli"
+               ReferencedContainer = "container:DriveWire.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      internalIOSLaunchStyle = "3"
+      viewDebuggingEnabled = "No"
+      queueDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "68A8420C2AD329B6009BE6D3"
+            BuildableName = "drivewire-cli"
+            ReferencedContainer = "container:DriveWire.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = " --tcp-port 65504"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = " --rfm-root /Users/boisy"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--disk0 /Users/boisy/Projects/coco-shelf/nitros9/recipes/coco3/dw_becker/l2_coco3_dw_becker.dsk"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--verbose"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "68A8420C2AD329B6009BE6D3"
+            BuildableName = "drivewire-cli"
+            ReferencedContainer = "container:DriveWire.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/swift/DriveWire/Drivers/DriveWireTCPDriver.swift
+++ b/swift/DriveWire/Drivers/DriveWireTCPDriver.swift
@@ -214,7 +214,7 @@ class DriveWireTCPServerDriver: NSObject, DriveWireDelegate, ObservableObject {
     }
 
     func start(port: UInt16) throws {
-        host = DriveWireHost(delegate: self)
+        host.delegate = self
         guard let nwPort = NWEndpoint.Port(rawValue: port) else {
             throw DriveWireHostError.nameNotFound
         }

--- a/swift/DriveWire/Drivers/DriveWireTCPDriver.swift
+++ b/swift/DriveWire/Drivers/DriveWireTCPDriver.swift
@@ -238,6 +238,7 @@ class DriveWireTCPServerDriver: NSObject, DriveWireDelegate, ObservableObject {
                 self?.receive(from: conn)
             case .failed, .cancelled:
                 print("DriveWire guest disconnected")
+                self?.host.resetRFMState()
                 self?.connection = nil
             default:
                 break
@@ -257,6 +258,7 @@ class DriveWireTCPServerDriver: NSObject, DriveWireDelegate, ObservableObject {
                 self?.receive(from: conn)
             } else {
                 print("DriveWire guest disconnected")
+                self?.host.resetRFMState()
                 self?.connection = nil
             }
         }

--- a/swift/DriveWire/Drivers/DriveWireTCPDriver.swift
+++ b/swift/DriveWire/Drivers/DriveWireTCPDriver.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Network
 
 /// Provides a TCP/IP interface to a DriveWire host.
 ///
@@ -191,5 +192,80 @@ extension DriveWireTCPDriver: StreamDelegate {
         default:
             break
         }
+    }
+}
+
+/// Provides a TCP server interface to a DriveWire host.
+///
+/// Listens for an incoming TCP connection (e.g. from MAME's `-bitb socket.127.0.0.1:<port>`)
+/// and serves a DriveWire guest over that connection.
+class DriveWireTCPServerDriver: NSObject, DriveWireDelegate, ObservableObject {
+    private var listener: NWListener?
+    private var connection: NWConnection?
+
+    public var logging = false
+    public var host: DriveWireHost = DriveWireHost()
+
+    func transactionCompleted(opCode: UInt8) {}
+
+    func dataAvailable(host: DriveWireHost, data: Data) {
+        if logging { data.dump(prefix: "<-") }
+        connection?.send(content: data, completion: .idempotent)
+    }
+
+    func start(port: UInt16) throws {
+        host = DriveWireHost(delegate: self)
+        guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+            throw DriveWireHostError.nameNotFound
+        }
+        listener = try NWListener(using: .tcp, on: nwPort)
+        listener?.newConnectionHandler = { [weak self] conn in self?.accept(conn) }
+        listener?.stateUpdateHandler = { state in
+            if case .ready = state {
+                print("DriveWire TCP server listening on port \(port)")
+            }
+        }
+        listener?.start(queue: .main)
+    }
+
+    private func accept(_ conn: NWConnection) {
+        connection?.cancel()
+        connection = conn
+        conn.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                print("DriveWire guest connected")
+                self?.receive(from: conn)
+            case .failed, .cancelled:
+                print("DriveWire guest disconnected")
+                self?.connection = nil
+            default:
+                break
+            }
+        }
+        conn.start(queue: .main)
+    }
+
+    private func receive(from conn: NWConnection) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, isComplete, error in
+            if let data = data, !data.isEmpty {
+                if self?.logging == true { data.dump(prefix: "->") }
+                var d = data
+                self?.host.send(data: &d)
+            }
+            if error == nil && !isComplete {
+                self?.receive(from: conn)
+            } else {
+                print("DriveWire guest disconnected")
+                self?.connection = nil
+            }
+        }
+    }
+
+    func stop() {
+        connection?.cancel()
+        listener?.cancel()
+        connection = nil
+        listener = nil
     }
 }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -67,6 +67,7 @@ public class DriveWireHost : Codable {
     var log : String = ""
 
     init() {
+        setupTransactions()
     }
     
     func reloadVirtualDrives() {

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1145,8 +1145,6 @@ public class DriveWireHost : Codable {
     }
 
     // Receives: path#(1) then count(2) then count bytes. No response.
-    // Receives: path#(1) then count(2) then count bytes. No response.
-    // Translates CR → LF since OS-9 uses CR as line terminator.
     private func OPRFMWRITLN(data: Data) -> Int {
         var result = 0
         let headerCount = 3

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -184,6 +184,27 @@ public class DriveWireHost : Codable {
             filePosition = end
             return (0, data)
         }
+
+        mutating func writeToFile(data: Data, translateCR: Bool = false) -> UInt8 {
+            guard let file = localFile else { return 216 }
+            do {
+                try file.seek(toOffset: UInt64(filePosition))
+                let bytesToWrite = translateCR
+                    ? Data(data.map { $0 == 0x0D ? 0x0A : $0 })
+                    : data
+                file.write(bytesToWrite)
+                // Keep fileContents in sync for subsequent reads
+                let end = filePosition + bytesToWrite.count
+                if fileContents.count < end {
+                    fileContents.append(Data(repeating: 0, count: end - fileContents.count))
+                }
+                fileContents.replaceSubrange(filePosition..<end, with: bytesToWrite)
+                filePosition = end
+            } catch {
+                return 216
+            }
+            return 0
+        }
     }
 
     var rfmRootPath: String = NSHomeDirectory()
@@ -1074,6 +1095,7 @@ public class DriveWireHost : Codable {
     }
 
     // Receives: path#(1) then count(2) then count bytes. No response.
+    // Receives: path#(1) then count(2) then count bytes. No response.
     private func OPRFMWRITE(data: Data) -> Int {
         var result = 0
         let headerCount = 3
@@ -1083,7 +1105,11 @@ public class DriveWireHost : Codable {
             let byteCount = Int(data[1]) * 256 + Int(data[2])
             let totalCount = headerCount + byteCount
             if data.count >= totalCount {
-                // TODO: write to file
+                if var descriptor = rfmPaths[pathNumber] {
+                    let writeData = data[headerCount..<totalCount]
+                    _ = descriptor.writeToFile(data: Data(writeData))
+                    rfmPaths[pathNumber] = descriptor
+                }
                 result = totalCount
                 resetState()
             }
@@ -1123,6 +1149,8 @@ public class DriveWireHost : Codable {
     }
 
     // Receives: path#(1) then count(2) then count bytes. No response.
+    // Receives: path#(1) then count(2) then count bytes. No response.
+    // Translates CR → LF since OS-9 uses CR as line terminator.
     private func OPRFMWRITLN(data: Data) -> Int {
         var result = 0
         let headerCount = 3
@@ -1132,7 +1160,11 @@ public class DriveWireHost : Codable {
             let byteCount = Int(data[1]) * 256 + Int(data[2])
             let totalCount = headerCount + byteCount
             if data.count >= totalCount {
-                // TODO: write to file
+                if var descriptor = rfmPaths[pathNumber] {
+                    let writeData = data[headerCount..<totalCount]
+                    _ = descriptor.writeToFile(data: Data(writeData), translateCR: true)
+                    rfmPaths[pathNumber] = descriptor
+                }
                 result = totalCount
                 resetState()
             }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -190,25 +190,19 @@ public class DriveWireHost : Codable {
             guard let file = localFile else { return 216 }
             let bytesToWrite: Data
             if translateCR {
-                // Convert CR→LF and strip $FF padding (OS-9 string terminator)
+                // Strip $FF padding (OS-9 string terminator) and convert CR→LF
                 var out = Data()
                 for byte in data {
-                    if byte == 0xFF { break }  // $FF = end of OS-9 string, discard padding
+                    if byte == 0xFF { break }
                     out.append(byte == 0x0D ? 0x0A : byte)
                 }
                 bytesToWrite = out
             } else {
                 bytesToWrite = data
             }
-            file.seek(toFileOffset: UInt64(filePosition))
             file.write(bytesToWrite)
             file.synchronizeFile()
-            let end = filePosition + bytesToWrite.count
-            if fileContents.count < end {
-                fileContents.append(Data(repeating: 0, count: end - fileContents.count))
-            }
-            fileContents.replaceSubrange(filePosition..<end, with: bytesToWrite)
-            filePosition = end
+            filePosition += bytesToWrite.count
             return 0
         }
     }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1030,8 +1030,41 @@ public class DriveWireHost : Codable {
     }
 
     private func OPRFMMAKDIR(data: Data) -> Int {
-        resetState()
-        return 0
+        var result = 0
+        let expectedCount = 3
+        var capturedPathNumber = 0
+
+        if data.count >= expectedCount {
+            capturedPathNumber = Int(data[0])
+            result = expectedCount
+            processor = OPRFMGETMKDIRPATH
+        }
+
+        return result
+
+        func OPRFMGETMKDIRPATH(data: Data) -> Int {
+            guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
+            let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let pathname = String(bytes: pathBytes, encoding: .ascii) ?? ""
+            var errorCode: UInt8 = 216
+            if !pathname.isEmpty && !pathname.contains("\0") {
+                let localPath = (pathname as NSString).isAbsolutePath
+                    ? rfmRootPath + pathname : rfmRootPath + "/" + pathname
+                let resolved = URL(filePath: localPath).standardized.path
+                let normalizedRoot = URL(filePath: rfmRootPath).standardized.path
+                if resolved == normalizedRoot || resolved.hasPrefix(normalizedRoot + "/") {
+                    do {
+                        try FileManager.default.createDirectory(
+                            atPath: resolved, withIntermediateDirectories: true)
+                        errorCode = 0
+                        log += "OP_RFM_MAKDIR(\(capturedPathNumber), \(pathname)) -> 0\n"
+                    } catch { errorCode = 216 }
+                } else { errorCode = 214 }
+            }
+            delegate?.dataAvailable(host: self, data: Data([errorCode]))
+            resetState()
+            return crOffset - data.startIndex + 1
+        }
     }
 
     private func OPRFMCHGDIR(data: Data) -> Int {

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1071,7 +1071,9 @@ public class DriveWireHost : Codable {
     }
 
     private func OPRFMCHGDIR(data: Data) -> Int {
-        return OPRFMOPEN(data: data)
+        // rfm.asm chgdir uses sendit — only the sub-opcode is sent, no path data.
+        resetState()
+        return 0
     }
 
     private func OPRFMDELETE(data: Data) -> Int {
@@ -1101,10 +1103,19 @@ public class DriveWireHost : Codable {
                     do {
                         let attrs = try FileManager.default.attributesOfItem(atPath: resolved)
                         if attrs[.type] as? FileAttributeType == .typeDirectory {
-                            errorCode = 214  // E$FNA — use deldir for directories
+                            // Only delete if empty (deldir path)
+                            let contents = try FileManager.default.contentsOfDirectory(atPath: resolved)
+                            if contents.isEmpty {
+                                try FileManager.default.removeItem(atPath: resolved)
+                                errorCode = 0
+                            } else {
+                                errorCode = 215  // E$DNE — directory not empty
+                            }
                         } else {
                             try FileManager.default.removeItem(atPath: resolved)
                             errorCode = 0
+                        }
+                        if errorCode == 0 {
                             log += "OP_RFM_DELETE(\(capturedPathNumber), \(pathname)) -> 0\n"
                         }
                     } catch { errorCode = 216 }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -126,7 +126,7 @@ public class DriveWireHost : Codable {
             }
 
             // Guard against path traversal escaping rfmRootPath.
-            guard !pathname.isEmpty else { return 216 }
+            guard !pathname.isEmpty && !pathname.contains("\0") else { return 216 }
             let resolvedPath = URL(filePath: localPathname).standardized.path
             let normalizedRoot = URL(filePath: rootPath).standardized.path
             guard resolvedPath == normalizedRoot || resolvedPath.hasPrefix(normalizedRoot + "/") else {

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -118,15 +118,14 @@ public class DriveWireHost : Codable {
         var attributes = [FileAttributeKey : Any]()
 
         mutating func openLocalFile(rootPath: String) -> UInt8 {
+            guard !pathname.isEmpty && !pathname.contains("\0") else { return 216 }
+
             let localPathname: String
             if (pathname as NSString).isAbsolutePath {
                 localPathname = rootPath + pathname
             } else {
                 localPathname = rootPath + "/" + pathname
             }
-
-            // Guard against path traversal escaping rfmRootPath.
-            guard !pathname.isEmpty && !pathname.contains("\0") else { return 216 }
             let resolvedPath = URL(filePath: localPathname).standardized.path
             let normalizedRoot = URL(filePath: rootPath).standardized.path
             guard resolvedPath == normalizedRoot || resolvedPath.hasPrefix(normalizedRoot + "/") else {

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1075,8 +1075,40 @@ public class DriveWireHost : Codable {
     }
 
     private func OPRFMDELETE(data: Data) -> Int {
-        resetState()
-        return 0
+        var result = 0
+        let expectedCount = 3
+        var capturedPathNumber = 0
+
+        if data.count >= expectedCount {
+            capturedPathNumber = Int(data[0])
+            result = expectedCount
+            processor = OPRFMGETDELETEPATH
+        }
+
+        return result
+
+        func OPRFMGETDELETEPATH(data: Data) -> Int {
+            guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
+            let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let pathname = String(bytes: pathBytes, encoding: .ascii) ?? ""
+            var errorCode: UInt8 = 216
+            if !pathname.isEmpty && !pathname.contains("\0") {
+                let localPath = (pathname as NSString).isAbsolutePath
+                    ? rfmRootPath + pathname : rfmRootPath + "/" + pathname
+                let resolved = URL(filePath: localPath).standardized.path
+                let normalizedRoot = URL(filePath: rfmRootPath).standardized.path
+                if resolved == normalizedRoot || resolved.hasPrefix(normalizedRoot + "/") {
+                    do {
+                        try FileManager.default.removeItem(atPath: resolved)
+                        errorCode = 0
+                        log += "OP_RFM_DELETE(\(capturedPathNumber), \(pathname)) -> 0\n"
+                    } catch { errorCode = 216 }
+                } else { errorCode = 214 }
+            }
+            delegate?.dataAvailable(host: self, data: Data([errorCode]))
+            resetState()
+            return crOffset - data.startIndex + 1
+        }
     }
 
     // Receives: path#(1) + X(2) + U(2) where X:U is the 32-bit seek position.

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -190,15 +190,15 @@ public class DriveWireHost : Codable {
             guard let file = localFile else { return 216 }
             let bytesToWrite: Data
             if translateCR {
-                // Strip trailing $FF and $00 padding, convert all $0D → $0A
-                var endIndex = data.endIndex
-                while endIndex > data.startIndex {
-                    let prev = data.index(before: endIndex)
-                    let byte = data[prev]
-                    if byte != 0x00 && byte != 0xFF { break }
-                    endIndex = prev
+                // Content ends at first $0D (everything after is stale buffer data).
+                // Convert $0D → $0A, discard remainder. Also stop at $FF (OS-9 padding).
+                var out = Data()
+                for byte in data {
+                    if byte == 0xFF { break }
+                    if byte == 0x0D { out.append(0x0A); break }
+                    out.append(byte)
                 }
-                bytesToWrite = Data(data[data.startIndex..<endIndex].map { $0 == 0x0D ? 0x0A : $0 })
+                bytesToWrite = out
             } else {
                 bytesToWrite = data
             }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -187,23 +187,18 @@ public class DriveWireHost : Codable {
 
         mutating func writeToFile(data: Data, translateCR: Bool = false) -> UInt8 {
             guard let file = localFile else { return 216 }
-            do {
-                try file.seek(toOffset: UInt64(filePosition))
-                let bytesToWrite = translateCR
-                    ? Data(data.map { $0 == 0x0D ? 0x0A : $0 })
-                    : data
-                file.write(bytesToWrite)
-                file.synchronizeFile()
-                // Keep fileContents in sync for subsequent reads
-                let end = filePosition + bytesToWrite.count
-                if fileContents.count < end {
-                    fileContents.append(Data(repeating: 0, count: end - fileContents.count))
-                }
-                fileContents.replaceSubrange(filePosition..<end, with: bytesToWrite)
-                filePosition = end
-            } catch {
-                return 216
+            let bytesToWrite = translateCR
+                ? Data(data.map { $0 == 0x0D ? 0x0A : $0 })
+                : data
+            file.seek(toFileOffset: UInt64(filePosition))
+            file.write(bytesToWrite)
+            file.synchronizeFile()
+            let end = filePosition + bytesToWrite.count
+            if fileContents.count < end {
+                fileContents.append(Data(repeating: 0, count: end - fileContents.count))
             }
+            fileContents.replaceSubrange(filePosition..<end, with: bytesToWrite)
+            filePosition = end
             return 0
         }
     }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1101,10 +1101,11 @@ public class DriveWireHost : Codable {
             let byteCount = Int(data[1]) * 256 + Int(data[2])
             let totalCount = headerCount + byteCount
             if data.count >= totalCount {
-                if var descriptor = rfmPaths[pathNumber] {
-                    let writeData = data[headerCount..<totalCount]
-                    _ = descriptor.writeToFile(data: Data(writeData))
-                    rfmPaths[pathNumber] = descriptor
+                let key = rfmPaths[pathNumber] != nil ? pathNumber
+                    : rfmPaths.first { $0.value.localFile != nil }?.key
+                if let k = key, var descriptor = rfmPaths[k] {
+                    _ = descriptor.writeToFile(data: Data(data[headerCount..<totalCount]))
+                    rfmPaths[k] = descriptor
                 }
                 result = totalCount
                 resetState()
@@ -1154,10 +1155,11 @@ public class DriveWireHost : Codable {
             let byteCount = Int(data[1]) * 256 + Int(data[2])
             let totalCount = headerCount + byteCount
             if data.count >= totalCount {
-                if var descriptor = rfmPaths[pathNumber] {
-                    let writeData = data[headerCount..<totalCount]
-                    _ = descriptor.writeToFile(data: Data(writeData), translateCR: true)
-                    rfmPaths[pathNumber] = descriptor
+                let key = rfmPaths[pathNumber] != nil ? pathNumber
+                    : rfmPaths.first { $0.value.localFile != nil }?.key
+                if let k = key, var descriptor = rfmPaths[k] {
+                    _ = descriptor.writeToFile(data: Data(data[headerCount..<totalCount]), translateCR: true)
+                    rfmPaths[k] = descriptor
                 }
                 result = totalCount
                 resetState()

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -202,6 +202,7 @@ public class DriveWireHost : Codable {
             } else {
                 bytesToWrite = data
             }
+            file.seek(toFileOffset: UInt64(filePosition))
             file.write(bytesToWrite)
             file.synchronizeFile()
             filePosition += bytesToWrite.count

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -596,8 +596,8 @@ public class DriveWireHost : Codable {
             if data.count >= nameLength {
                 resetState()
                 result = nameLength;
-                let name = String(bytes: data, encoding: .ascii)!
-                
+                let name = String(bytes: data, encoding: .ascii) ?? ""
+
                 // determine if a named object with this name already exists
                 if let vd = findVirtualDisk(name: name) {
                     response = UInt8(vd.driveNumber)
@@ -613,11 +613,11 @@ public class DriveWireHost : Codable {
                 delegate?.dataAvailable(host: self, data: Data([response]))
                 delegate?.transactionCompleted(opCode: currentTransaction)
             }
-            
+
             return result
         }
     }
-    
+
     private func OP_NAMEOBJ_CREATE(data : Data) -> Int {
         var nameLength = 0
         var result = 0
@@ -639,8 +639,8 @@ public class DriveWireHost : Codable {
             if data.count >= nameLength {
                 resetState()
                 result = nameLength;
-                let name = String(bytes: data, encoding: .ascii)!
-                
+                let name = String(bytes: data, encoding: .ascii) ?? ""
+
                 // determine if a named object with this name already exists
                 if let _ = findVirtualDisk(name: name) {
                     response = 0
@@ -650,13 +650,13 @@ public class DriveWireHost : Codable {
                         try insertVirtualDisk(driveNumber: nextFreeDrive, imagePath: name)
                         response = UInt8(nextFreeDrive);
                     } catch {
-                        
+
                     }
                 }
                 delegate?.dataAvailable(host: self, data: Data([response]))
                 delegate?.transactionCompleted(opCode: currentTransaction)
             }
-            
+
             return result
         }
     }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -511,9 +511,10 @@ public class DriveWireHost : Codable {
         repeat
         {
             bytesConsumed = self.processor!(serialBuffer)
-            
+
             if bytesConsumed > 0  && serialBuffer.count >= bytesConsumed {
-                // chop off consumed bytes
+                // Bytes were consumed — cancel the idle watchdog while mid-transaction.
+                invalidateWatchdog()
                 serialBuffer.replaceSubrange(0..<bytesConsumed, with: Data([]))
             }
         } while bytesConsumed > 0 && serialBuffer.count > 0

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -105,33 +105,26 @@ public class DriveWireHost : Codable {
     private var processor : ((Data) -> Int)?
     
     struct RFMPathDescriptor {
-        var processID = 0
         var pathNumber = 0
-        var pathDescriptorAddress = 0
         var mode = 0
         var filePosition = 0
-        var pathnameLength = 0
         var pathname = ""
-        var errorCode : UInt8 = 0
         var localFile : FileHandle? = nil
         var fileContents : Data = Data()
         var attributes = [FileAttributeKey : Any]()
-        
-        mutating func openLocalFile() -> UInt8 {
+
+        mutating func openLocalFile(rootPath: String) -> UInt8 {
             var errorCode : UInt8 = 0
-            
-            var localPathname = pathname
-            if (localPathname as NSString).isAbsolutePath == false {
-                // TODO: resolve relative paths
+            let localPathname: String
+            if (pathname as NSString).isAbsolutePath {
+                localPathname = rootPath + pathname
+            } else {
+                localPathname = rootPath + "/" + pathname
             }
             do {
-                localPathname = "/Users/boisy" + localPathname
-                attributes = try FileManager().attributesOfItem(atPath: localPathname)
-                
-                // Determine if we're opening a directory
+                attributes = try FileManager.default.attributesOfItem(atPath: localPathname)
                 if mode & 0x80 != 0 {
-                    // We're expecting this to be a directory
-                    if let fileType = attributes[FileAttributeKey.type] as? String, fileType != "NSFileTypeDirectory" {
+                    if let fileType = attributes[.type] as? FileAttributeType, fileType != .typeDirectory {
                         errorCode = 214
                     }
                 } else {
@@ -143,7 +136,6 @@ public class DriveWireHost : Codable {
             } catch {
                 errorCode = 216
             }
-            
             return errorCode
         }
 
@@ -195,9 +187,8 @@ public class DriveWireHost : Codable {
         }
     }
 
-    var rfmWorkingDataDirectoryPathDescriptor = RFMPathDescriptor()
-    var rfmWorkingExecutionDirectoryPathDescriptor = RFMPathDescriptor()
-    var rfmPathDescriptor = RFMPathDescriptor()
+    var rfmRootPath: String = NSHomeDirectory()
+    private var rfmPaths: [Int: RFMPathDescriptor] = [:]
     
     /// The no-operation transaction code.
     ///
@@ -965,432 +956,211 @@ public class DriveWireHost : Codable {
     }
     
     private func OPRFMCREATE(data : Data) -> Int {
-        var result = 0
-        let expectedCount = 2
-        
-        if data.count >= expectedCount {
-            
-            resetState()
-        }
-        
-        return result
+        // Create is handled identically to Open on the host side.
+        return OPRFMOPEN(data: data)
     }
-    
-    // Format of command from the client at this point
-    // - 2 byte: Path descriptor address (we use this as part of a unique identifier for this path)
-    // - 1 byte: Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 1 byte: Mode Byte from caller's R$A
-    // - 2 bytes: length of pathname
+
+    // Receives: path#(1) + mode(1), then pathname terminated by CR ($0D).
+    // Sends back: 1-byte error code.
     private func OPRFMOPEN(data : Data) -> Int {
         var result = 0
-        let expectedCount = 7
+        let expectedCount = 2
+        var capturedPathNumber = 0
 
         if data.count >= expectedCount {
-            rfmPathDescriptor = RFMPathDescriptor()
-            rfmPathDescriptor.processID = Int(data[0])
-            rfmPathDescriptor.pathNumber = Int(data[1])
-            rfmPathDescriptor.pathDescriptorAddress = Int(data[2]) * 256 + Int(data[3])
-            rfmPathDescriptor.mode = Int(data[4])
-            rfmPathDescriptor.pathnameLength = Int(data[5]) * 256 + Int(data[6])
-            
+            capturedPathNumber = Int(data[0])
+            var descriptor = RFMPathDescriptor()
+            descriptor.pathNumber = capturedPathNumber
+            descriptor.mode = Int(data[1])
+            rfmPaths[capturedPathNumber] = descriptor
             result = expectedCount
             processor = OPRFMGETPATH
-            log = log + "OP_RFM_OPEN("
         }
-        
+
         return result
-    }
 
-    private func OPRFMGETPATH(data : Data) -> Int {
-        var result = 0
-        let expectedCount = rfmPathDescriptor.pathnameLength
-
-        if data.count >= expectedCount {
-            var lsn0 : UInt8 = 0
-            var lsn1 : UInt8 = 0
-            var lsn2 : UInt8 = 0
-            
-            if currentSubTransaction == DWRFMTransaction.OP_RFM_CHGDIR.rawValue {
-                
-            } else {
-                rfmPathDescriptor.pathname = String(bytes: data, encoding: .ascii)!
-            }
-
-            result = expectedCount
-            
-            // Locate the file on the host.
-            let errorCode = rfmPathDescriptor.openLocalFile()
-
-            if errorCode == 0 {
-                // obtain unique identifier
-                lsn0 = 3
-                lsn1 = 2
-                lsn2 = 1
-            }
-            
-            delegate?.dataAvailable(host: self, data: Data([errorCode, lsn0, lsn1, lsn2]))
-            log = log + "\(rfmPathDescriptor.pathDescriptorAddress), \(rfmPathDescriptor.pathNumber), \(rfmPathDescriptor.pathname)) -> [\(errorCode), \(lsn0), \(lsn1), \(lsn2)]\n"
-
-            resetState()
-        }
-        
-        return result
-    }
-    
-    private func OPRFMMAKDIR(data : Data) -> Int {
-        var result = 1
-        return result
-    }
-
-    private func OPRFMCHGDIR(data : Data) -> Int {
-        var result = 0
-        let expectedCount = 7
-        var mode = 0
-        
-        if data.count >= expectedCount {
-            let processID = Int(data[0])
-            let pathNumber = Int(data[1])
-            let pathDescriptorAddress = Int(data[2]) * 256 + Int(data[3])
-            mode = Int(data[4])
-            let pathnameLength = Int(data[5]) * 256 + Int(data[6])
-
-            if mode & 0x4 != 0 {
-                // execution directory
-                rfmWorkingExecutionDirectoryPathDescriptor.processID = processID
-                rfmWorkingExecutionDirectoryPathDescriptor.pathNumber = pathNumber
-                rfmWorkingExecutionDirectoryPathDescriptor.pathDescriptorAddress = pathDescriptorAddress
-                rfmWorkingExecutionDirectoryPathDescriptor.mode = mode
-                rfmWorkingExecutionDirectoryPathDescriptor.pathnameLength = pathnameLength
-            } else {
-                // data directory
-                rfmWorkingDataDirectoryPathDescriptor.processID = processID
-                rfmWorkingDataDirectoryPathDescriptor.pathNumber = pathNumber
-                rfmWorkingDataDirectoryPathDescriptor.pathDescriptorAddress = pathDescriptorAddress
-                rfmWorkingDataDirectoryPathDescriptor.mode = mode
-                rfmWorkingDataDirectoryPathDescriptor.pathnameLength = pathnameLength
-            }
-            
-            result = expectedCount
-            processor = OPRFMGETCHGDIRPATH
-        }
-        
-        return result
-        
-        func OPRFMGETCHGDIRPATH(data : Data) -> Int {
-            var result = 0
-            let expectedCount = rfmPathDescriptor.pathnameLength
-            var errorCode : UInt8 = 0
-            
-            if data.count >= expectedCount {
-                var lsn0 : UInt8 = 0
-                var lsn1 : UInt8 = 0
-                var lsn2 : UInt8 = 0
-
-                if mode & 0x4 != 0 {
-                    // execution directory
-                    rfmWorkingExecutionDirectoryPathDescriptor.pathname = String(bytes: data, encoding: .ascii)!
-                    errorCode = rfmWorkingExecutionDirectoryPathDescriptor.openLocalFile()
-                } else {
-                    // data directory
-                    rfmWorkingDataDirectoryPathDescriptor.pathname = String(bytes: data, encoding: .ascii)!
-                    errorCode = rfmWorkingDataDirectoryPathDescriptor.openLocalFile()
-                }
-
-                result = expectedCount
-                
-                // Locate the file on the host.
-
-                if errorCode == 0 {
-                    // obtain unique identifier
-                    lsn0 = 3
-                    lsn1 = 2
-                    lsn2 = 1
-                }
-                
-                if mode & 0x4 != 0 {
-                    // execution directory
-                    log = log + "OP_RFM_CHGDIR(Execution, \(rfmWorkingExecutionDirectoryPathDescriptor.pathDescriptorAddress), \(rfmWorkingExecutionDirectoryPathDescriptor.pathNumber), \(rfmWorkingExecutionDirectoryPathDescriptor.pathname)) -> [\(errorCode), \(lsn0), \(lsn1), \(lsn2)]\n"
-                } else {
-                    // data directory
-                    log = log + "OP_RFM_CHGDIR(Data, \(rfmWorkingDataDirectoryPathDescriptor.pathDescriptorAddress), \(rfmWorkingDataDirectoryPathDescriptor.pathNumber), \(rfmWorkingDataDirectoryPathDescriptor.pathname)) -> [\(errorCode), \(lsn0), \(lsn1), \(lsn2)]\n"
-                }
-
-                delegate?.dataAvailable(host: self, data: Data([errorCode, lsn0, lsn1, lsn2]))
-
-                resetState()
-            }
-            
-            return result
-        }
-    }
-
-private func OPRFMDELETE(data : Data) -> Int {
-    var result = 1
-    return result
-}
-
-    // Format of command from the client at this point
-    // - 2 byte: Path descriptor address (we use this as part of a unique identifier for this path)
-    // - 1 byte: Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 4 bytes: 32-bit seek position
-    private func OPRFMSEEK(data : Data) -> Int {
-        var result = 0
-        let expectedCount = 7
-        var errorCode : UInt8 = 0
-
-        if data.count >= expectedCount {
-            rfmPathDescriptor.pathDescriptorAddress = Int(data[0]) * 256 + Int(data[1])
-            rfmPathDescriptor.pathNumber = Int(data[2])
-            rfmPathDescriptor.filePosition = Int(data[3]) * 16777216 + Int(data[4]) * 65536 + Int(data[5]) * 256 + Int(data[6])
-
-            result = expectedCount
-            resetState()
+        func OPRFMGETPATH(data: Data) -> Int {
+            guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
+            let pathname = String(bytes: data[data.startIndex..<crOffset], encoding: .ascii) ?? ""
+            rfmPaths[capturedPathNumber]?.pathname = pathname
+            let errorCode = rfmPaths[capturedPathNumber]?.openLocalFile(rootPath: rfmRootPath) ?? 0xFF
             delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            log = log + "OP_RFM_SEEK(\(rfmPathDescriptor.filePosition)) -> R$B=\(errorCode)\n"
+            log += "OP_RFM_OPEN(\(capturedPathNumber), \(pathname)) -> \(errorCode)\n"
+            resetState()
+            return crOffset - data.startIndex + 1
         }
-        
-        return result
     }
 
-    // Read data from the client.
-    //
-    // Format of command from the client at this point
-    // - 1 byte:  Process ID
-    // - 1 byte:  Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 2 bytes: Path descriptor address (we use this as part of a unique identifier for this path)
-    // - 2 bytes: Number of bytes to read
-    //
-    // If there is an error, then the following bytes are sent to the client, and the transaction terminates:
-    // - 1 byte:  a non-zero error code
-    // - 2 bytes: size to read (0)
-    //
-    // If there is NOT an error, then the following bytes are sent to the client:
-    // - 1 byte: 0 (no error)
-    // - 2 bytes: the number of bytes the client can read
-    //
-    // Upon receiving the non-error 3-byte response, the client will then issue a "ready" response of 1 byte.
-    // When the host receives the "ready" response, it will send the number of bytes to the client.
-    private func OPRFMREAD(data : Data) -> Int {
-        var pathDescriptorAddress = 0
-        var pathNumber = 0
-        var bytesToRead = 0
-        var errorCode : UInt8 = 0
-        var dataToSend = Data([0x00])
+    private func OPRFMMAKDIR(data: Data) -> Int {
+        resetState()
+        return 0
+    }
 
-        // Format of command from the client at this point
-        // - 1 byte: 0 = acknowledged previous response
-        func OPRFMREADP2(data : Data) -> Int {
-            var result = 0
-            let expectedCount = 1
-            
-            if data.count >= expectedCount {
-                result = expectedCount
-                delegate?.dataAvailable(host: self, data: dataToSend)
-            }
+    private func OPRFMCHGDIR(data: Data) -> Int {
+        return OPRFMOPEN(data: data)
+    }
 
-            resetState()
+    private func OPRFMDELETE(data: Data) -> Int {
+        resetState()
+        return 0
+    }
 
-            return result
-        }
-
+    // Receives: path#(1) + X(2) + U(2) where X:U is the 32-bit seek position.
+    // Sends back: 1-byte error code.
+    private func OPRFMSEEK(data: Data) -> Int {
         var result = 0
         let expectedCount = 5
-        
+        var errorCode: UInt8 = 0
+
         if data.count >= expectedCount {
-            pathDescriptorAddress = Int(data[0]) * 256 + Int(data[1])
-            pathNumber = Int(data[2])
-            bytesToRead = Int(data[3]) * 256 + Int(data[4])
+            let pathNumber = Int(data[0])
+            let position = Int(data[1]) * 16777216 + Int(data[2]) * 65536 + Int(data[3]) * 256 + Int(data[4])
+            rfmPaths[pathNumber]?.filePosition = position
             result = expectedCount
-            
-            // Get number of bytes to read from file on this path.
-            
-            // Send the response code to the guest.
-            // Format of response:
-            // - 1 byte: error code
-            // - 2 bytes: length of valid data
-            (errorCode, dataToSend) = rfmPathDescriptor.readFromFile(offset: 0, maximumCount : bytesToRead)
+            resetState()
             delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            delegate?.dataAvailable(host: self, data: Data([UInt8((dataToSend.count >> 8) & 0xFF), UInt8(dataToSend.count & 0xFF)]))
-            if errorCode == 0 {
-                processor = OPRFMREADP2
+            log += "OP_RFM_SEEK(\(pathNumber), \(position)) -> \(errorCode)\n"
+        }
+
+        return result
+    }
+
+    // Receives: path#(1) then maxBytes(2). Sends: count(1) then count bytes.
+    // count=0 signals EOF; rfm.asm treats it as E$EOF.
+    private func OPRFMREAD(data: Data) -> Int {
+        var result = 0
+        let expectedCount = 3
+
+        if data.count >= expectedCount {
+            let pathNumber = Int(data[0])
+            let maxBytes = min(Int(data[1]) * 256 + Int(data[2]), 255)
+            result = expectedCount
+
+            if var descriptor = rfmPaths[pathNumber] {
+                let (errorCode, lineData) = descriptor.readFromFile(offset: descriptor.filePosition, maximumCount: maxBytes)
+                rfmPaths[pathNumber] = descriptor
+                if errorCode != 0 {
+                    delegate?.dataAvailable(host: self, data: Data([0x00]))
+                } else {
+                    delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count)]))
+                    if !lineData.isEmpty {
+                        delegate?.dataAvailable(host: self, data: lineData)
+                    }
+                }
             } else {
+                delegate?.dataAvailable(host: self, data: Data([0x00]))
+            }
+            resetState()
+        }
+
+        return result
+    }
+
+    // Receives: path#(1) then count(2) then count bytes. No response.
+    private func OPRFMWRITE(data: Data) -> Int {
+        var result = 0
+        let headerCount = 3
+
+        if data.count >= headerCount {
+            let pathNumber = Int(data[0])
+            let byteCount = Int(data[1]) * 256 + Int(data[2])
+            let totalCount = headerCount + byteCount
+            if data.count >= totalCount {
+                // TODO: write to file
+                result = totalCount
                 resetState()
             }
         }
-        
+
         return result
     }
 
-    private func OPRFMWRITE(data : Data) -> Int {
-        var result = 1
-        return result
-    }
+    // Receives: path#(1) then maxBytes(2). Sends: count(1) then count bytes.
+    private func OPRFMREADLN(data: Data) -> Int {
+        var result = 0
+        let expectedCount = 3
 
-    // Read data from the client up to a new line.
-    //
-    // Format of command from the client at this point
-    // - 1 byte:  Process ID
-    // - 1 byte:  Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 2 bytes: Path descriptor address (we use this as part of a unique identifier for this path)
-    // - 2 bytes: Number of bytes to read
-    //
-    // If there is an error, then the following bytes are sent to the client, and the transaction terminates:
-    // - 1 byte:  a non-zero error code
-    // - 2 bytes: (0, 0)
-    //
-    // If there is NOT an error, then the following bytes are sent to the client:
-    // - 1 byte: 0 (no error)
-    // - 2 bytes: the number of bytes the client can read
-    //
-    // Upon receiving the non-error 3-byte response, the client will then issue a "ready" response of 1 byte.
-    // When the host receives the "ready" response, it sends the number of requested bytes to the client.
-    private func OPRFMREADLN(data : Data) -> Int {
-        var pathDescriptorAddress = 0
-        var pathNumber = 0
-        var bytesToRead = 0
-        var errorCode : UInt8 = 0
-        var dataToSend = Data([0x00])
+        if data.count >= expectedCount {
+            let pathNumber = Int(data[0])
+            let maxBytes = min(Int(data[1]) * 256 + Int(data[2]), 255)
+            result = expectedCount
 
-        // Format of command from the client at this point
-        // - 1 byte: 0 = acknowledged previous response
-        func OPRFMREADP2(data : Data) -> Int {
-            var result = 0
-            let expectedCount = 1
-            
-            if data.count >= expectedCount {
-                result = expectedCount
-                delegate?.dataAvailable(host: self, data: dataToSend)
+            if var descriptor = rfmPaths[pathNumber] {
+                let (errorCode, lineData) = descriptor.readLineFromFile(offset: descriptor.filePosition, maximumCount: maxBytes)
+                rfmPaths[pathNumber] = descriptor
+                if errorCode != 0 {
+                    delegate?.dataAvailable(host: self, data: Data([0x00]))
+                } else {
+                    delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count)]))
+                    if !lineData.isEmpty {
+                        delegate?.dataAvailable(host: self, data: lineData)
+                    }
+                }
+            } else {
+                delegate?.dataAvailable(host: self, data: Data([0x00]))
             }
-
             resetState()
-
-            return result
         }
 
+        return result
+    }
+
+    // Receives: path#(1) then count(2) then count bytes. No response.
+    private func OPRFMWRITLN(data: Data) -> Int {
         var result = 0
-        let expectedCount = 5
-        
-        if data.count >= expectedCount {
-            pathDescriptorAddress = Int(data[0]) * 256 + Int(data[1])
-            pathNumber = Int(data[2])
-            bytesToRead = Int(data[3]) * 256 + Int(data[4])
-            result = expectedCount
-            
-            // Get number of bytes to read from file on this path.
-            
-            // Send the response code to the guest.
-            // Format of response:
-            // - 1 byte: error code
-            // - 2 bytes: length of valid data
-            (errorCode, dataToSend) = rfmPathDescriptor.readLineFromFile(offset: 0, maximumCount: bytesToRead)
-            delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            delegate?.dataAvailable(host: self, data: Data([UInt8((dataToSend.count >> 8) & 0xFF), UInt8(dataToSend.count & 0xFF)]))
-            if errorCode == 0 {
-                processor = OPRFMREADP2
-            } else {
+        let headerCount = 3
+
+        if data.count >= headerCount {
+            let pathNumber = Int(data[0])
+            let byteCount = Int(data[1]) * 256 + Int(data[2])
+            let totalCount = headerCount + byteCount
+            if data.count >= totalCount {
+                // TODO: write to file
+                result = totalCount
                 resetState()
             }
         }
-        
+
         return result
     }
 
-    private func OPRFMWRITLN(data : Data) -> Int {
-        var result = 1
-        return result
-    }
-
-    // Perform a GetStat on behalf of the client.
-    //
-    // Format of command from the client at this point
-    // - 1 byte:  Process ID
-    // - 1 byte:  Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 2 bytes: Path descriptor address (we use this as part of a unique identifier for this path)
-    // - 1 byte:  GetStat code
-    //
-    // Responses from the host depend upon the GetStat code.
-    private func OPRFMGETSTT(data : Data) -> Int {
+    // Receives: path#(1) + SS.code(1). rfm.asm's getstt handlers are stubs, so send nothing.
+    private func OPRFMGETSTT(data: Data) -> Int {
         var result = 0
-        let expectedCount = 4
-        var errorCode : UInt8 = 0
+        let expectedCount = 2
 
         if data.count >= expectedCount {
-            rfmPathDescriptor.pathDescriptorAddress = Int(data[0]) * 256 + Int(data[1])
-            rfmPathDescriptor.pathNumber = Int(data[2])
-            let statCode = Int(data[3])
-            
-            switch statCode {
-            case 2:
-                // return file size
-                let count = rfmPathDescriptor.fileContents.count
-                delegate?.dataAvailable(host: self, data: Data([errorCode, UInt8((count & 0xFF000000) >> 24), UInt8((count & 0x00FF0000) >> 16), UInt8((count & 0x0000FF00) >> 8), UInt8((count & 0x000000FF) >> 0)]))
-                log = log + "OP_RFM_GETSTAT(SS.Size) -> R$B=\(errorCode), R$X=\((count & 0xFFFF0000) >> 16), R$U=\((count & 0x0000FFFF) >> 0)\n"
-                
-            default:
-                log = log + "OP_RFM_GETSTAT(\(statCode))\n"
-            }
-            
+            let pathNumber = Int(data[0])
+            let statCode = Int(data[1])
             result = expectedCount
             resetState()
+            log += "OP_RFM_GETSTT(\(pathNumber), \(statCode))\n"
         }
-        
+
         return result
     }
 
-    // Perform a SetStat on behalf of the client.
-    //
-    // Format of command from the client at this point
-    // - 1 byte:  Process ID
-    // - 1 byte:  Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 2 bytes: Path descriptor address (we use this as part of a unique identifier for this path)
-    // - 1 byte:  SetStat code
-    //
-    // Responses from the host depend upon the SetStat code.
-    private func OPRFMSETSTT(data : Data) -> Int {
-        var result = 0
-        let expectedCount = 4
-        var errorCode : UInt8 = 0
-
-        if data.count >= expectedCount {
-            rfmPathDescriptor.pathDescriptorAddress = Int(data[0]) * 256 + Int(data[1])
-            rfmPathDescriptor.pathNumber = Int(data[2])
-            let statCode = Int(data[3])
-            
-            result = expectedCount
-            resetState()
-            delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            log = log + "OP_RFM_SETSTAT(\(statCode))\n"
-        }
-        
-        return result
+    // Receives nothing (rfm.asm sendit only sends the sub-op). No response.
+    private func OPRFMSETSTT(data: Data) -> Int {
+        resetState()
+        return 0
     }
 
-    // Perform a close on behalf of the client.
-    //
-    // Format of command from the client at this point
-    // - 1 byte:  Process ID
-    // - 1 byte:  Path number (0-15; we use this as part of a unique identifier for this path)
-    // - 2 bytes: Path descriptor address (we use this as part of a unique identifier for this path)
-    //
-    // The host responds with a single error code.
-    private func OPRFMCLOSE(data : Data) -> Int {
+    // Receives: path#(1). Sends back: 1-byte error code.
+    private func OPRFMCLOSE(data: Data) -> Int {
         var result = 0
-        let expectedCount = 4
-        var errorCode : UInt8 = 0
-        
+        let expectedCount = 1
+
         if data.count >= expectedCount {
-            let processID = Int(data[0])
-            let pathNumber = Int(data[1])
-            let pathDescriptorAddress = Int(data[2]) * 256 + Int(data[3])
-            
+            let pathNumber = Int(data[0])
+            rfmPaths[pathNumber]?.localFile?.closeFile()
+            rfmPaths.removeValue(forKey: pathNumber)
             result = expectedCount
-
-            errorCode = 0
-            delegate?.dataAvailable(host: self, data: Data([errorCode]))
-
+            delegate?.dataAvailable(host: self, data: Data([0x00]))
             resetState()
+            log += "OP_RFM_CLOSE(\(pathNumber))\n"
         }
-        
+
         return result
     }
 

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -188,9 +188,18 @@ public class DriveWireHost : Codable {
 
         mutating func writeToFile(data: Data, translateCR: Bool = false) -> UInt8 {
             guard let file = localFile else { return 216 }
-            let bytesToWrite = translateCR
-                ? Data(data.map { $0 == 0x0D ? 0x0A : $0 })
-                : data
+            let bytesToWrite: Data
+            if translateCR {
+                // Convert CR→LF and strip $FF padding (OS-9 string terminator)
+                var out = Data()
+                for byte in data {
+                    if byte == 0xFF { break }  // $FF = end of OS-9 string, discard padding
+                    out.append(byte == 0x0D ? 0x0A : byte)
+                }
+                bytesToWrite = out
+            } else {
+                bytesToWrite = data
+            }
             file.seek(toFileOffset: UInt64(filePosition))
             file.write(bytesToWrite)
             file.synchronizeFile()

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -113,6 +113,7 @@ public class DriveWireHost : Codable {
         var filePosition = 0
         var pathname = ""
         var shouldCreate = false
+        var pendingClose = false
         var localFile : FileHandle? = nil
         var fileContents : Data = Data()
         var attributes = [FileAttributeKey : Any]()
@@ -1192,14 +1193,22 @@ public class DriveWireHost : Codable {
     }
 
     // Receives: path#(1). Sends back: 1-byte error code.
+    // Receives: path#(1). Sends back: 1-byte error code.
+    // If the path was opened via CREATE, the shell closes its reference after
+    // forking the child writer — keep the descriptor alive for incoming writes.
     private func OPRFMCLOSE(data: Data) -> Int {
         var result = 0
         let expectedCount = 1
 
         if data.count >= expectedCount {
             let pathNumber = Int(data[0])
-            rfmPaths[pathNumber]?.localFile?.closeFile()
-            rfmPaths.removeValue(forKey: pathNumber)
+            if let descriptor = rfmPaths[pathNumber], descriptor.shouldCreate && !descriptor.pendingClose {
+                // First close of a CREATE'd path — stay open for child writes
+                rfmPaths[pathNumber]?.pendingClose = true
+            } else {
+                rfmPaths[pathNumber]?.localFile?.closeFile()
+                rfmPaths.removeValue(forKey: pathNumber)
+            }
             result = expectedCount
             delegate?.dataAvailable(host: self, data: Data([0x00]))
             resetState()

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -307,7 +307,8 @@ public class DriveWireHost : Codable {
 
     var rfmRootPath: String = NSHomeDirectory()
     private var rfmPaths: [Int: RFMPathDescriptor] = [:]
-    private var rfmCurrentDir: [Int: String] = [:]
+    private var rfmCurrentDir: [Int: String] = [:]      // data directory per process
+    private var rfmCurrentExecDir: [Int: String] = [:] // execution directory per process
     // Maps host path ↔ unique LSN for synthesized RFM directory entries.
     // LSNs start above a typical NitrOS-9 DW image (~524k sectors for DW format).
     private var rfmLSNByPath: [String: Int] = [:]
@@ -684,6 +685,7 @@ public class DriveWireHost : Codable {
         }
         rfmPaths.removeAll()
         rfmCurrentDir.removeAll()
+        rfmCurrentExecDir.removeAll()
         rfmLSNByPath.removeAll()
         rfmLSNToPath.removeAll()
         rfmLSNCounter = 0x600000
@@ -1160,8 +1162,10 @@ public class DriveWireHost : Codable {
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
             let pid = rfmPaths[capturedPathNumber]?.processID ?? 0
             let ppid = rfmPaths[capturedPathNumber]?.parentProcessID ?? 0
+            let mode = rfmPaths[capturedPathNumber]?.mode ?? 0
+            let isExec = (mode & 0x04) != 0
             let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
-                                              processID: pid, parentProcessID: ppid)
+                                              processID: pid, parentProcessID: ppid, isExec: isExec)
             rfmPaths[capturedPathNumber]?.pathname = pathname
             let errorCode = rfmPaths[capturedPathNumber]?.openLocalFile(rootPath: rfmRootPath, shouldCreate: shouldCreate) ?? 0xFF
             if errorCode != 0 {
@@ -1173,7 +1177,11 @@ public class DriveWireHost : Codable {
                 rfmPaths[capturedPathNumber]?.fileContents = synthesizeDirectoryEntries(for: descriptor)
             }
             delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            let msg = "OP_RFM_\(shouldCreate ? "CREATE" : "OPEN")(path#\(capturedPathNumber), pid=\(pid), ppid=\(ppid), mode=0x\(String(rfmPaths[capturedPathNumber]?.mode ?? 0, radix: 16)), cwd=\(rfmCurrentDir[pid] ?? rfmCurrentDir[ppid] ?? "none"), resolved=\(pathname)) -> \(errorCode)"
+            let dirLabel = isExec ? "execDir" : "cwd"
+            let dirVal = isExec
+                ? (rfmCurrentExecDir[pid] ?? rfmCurrentExecDir[ppid] ?? "none")
+                : (rfmCurrentDir[pid] ?? rfmCurrentDir[ppid] ?? "none")
+            let msg = "OP_RFM_\(shouldCreate ? "CREATE" : "OPEN")(path#\(capturedPathNumber), pid=\(pid), ppid=\(ppid), mode=0x\(String(mode, radix: 16)), \(dirLabel)=\(dirVal), resolved=\(pathname)) -> \(errorCode)"
             log += msg + "\n"
             print(msg)
             resetState()
@@ -1181,12 +1189,13 @@ public class DriveWireHost : Codable {
         }
     }
 
-    private func resolveRFMPathname(_ pathname: String, processID: Int, parentProcessID: Int) -> String {
+    private func resolveRFMPathname(_ pathname: String, processID: Int, parentProcessID: Int, isExec: Bool = false) -> String {
         guard !(pathname as NSString).isAbsolutePath else { return pathname }
+        let dirMap = isExec ? rfmCurrentExecDir : rfmCurrentDir
         let base: String
-        if let cwd = rfmCurrentDir[processID] {
+        if let cwd = dirMap[processID] {
             base = cwd
-        } else if let cwd = rfmCurrentDir[parentProcessID] {
+        } else if let cwd = dirMap[parentProcessID] {
             base = cwd
         } else {
             return pathname
@@ -1289,11 +1298,13 @@ public class DriveWireHost : Codable {
         var capturedPathNumber = 0
         var capturedProcessID = 0
         var capturedParentProcessID = 0
+        var capturedMode = 0
 
         if data.count >= expectedCount {
             capturedPathNumber = Int(data[0])
             capturedProcessID = Int(data[1])
             capturedParentProcessID = Int(data[2])
+            capturedMode = Int(data[3])
             result = expectedCount
             processor = OPRFMGETMKDIRPATH
         }
@@ -1303,9 +1314,11 @@ public class DriveWireHost : Codable {
         func OPRFMGETMKDIRPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let isExec = (capturedMode & 0x04) != 0
             let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
                                               processID: capturedProcessID,
-                                              parentProcessID: capturedParentProcessID)
+                                              parentProcessID: capturedParentProcessID,
+                                              isExec: isExec)
             var errorCode: UInt8 = 216
             if !pathname.isEmpty && !pathname.contains("\0") {
                 let localPath = (pathname as NSString).isAbsolutePath
@@ -1334,11 +1347,13 @@ public class DriveWireHost : Codable {
         var capturedPathNumber = 0
         var capturedProcessID = 0
         var capturedParentProcessID = 0
+        var capturedMode = 0
 
         if data.count >= expectedCount {
             capturedPathNumber = Int(data[0])
             capturedProcessID = Int(data[1])
             capturedParentProcessID = Int(data[2])
+            capturedMode = Int(data[3])
             result = expectedCount
             processor = OPRFMGETCHGDIRPATH
         }
@@ -1348,9 +1363,11 @@ public class DriveWireHost : Codable {
         func OPRFMGETCHGDIRPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let isExec = (capturedMode & 0x04) != 0
             let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
                                               processID: capturedProcessID,
-                                              parentProcessID: capturedParentProcessID)
+                                              parentProcessID: capturedParentProcessID,
+                                              isExec: isExec)
             let expandedPathname = expandOS9MultiDots(pathname)
             var errorCode: UInt8 = 216
             if !expandedPathname.isEmpty && !expandedPathname.contains("\0") {
@@ -1368,16 +1385,23 @@ public class DriveWireHost : Codable {
                     if relativePath.isEmpty { relativePath = deviceRoot }
                     // Only store this process's CWD when it differs from the parent's.
                     // If it matches, remove any stale entry so the parent lookup always wins.
-                    // This prevents a child's chgdir(".") from caching a value that would
-                    // hide a subsequent chd by the parent.
-                    if relativePath == rfmCurrentDir[capturedParentProcessID] {
-                        rfmCurrentDir.removeValue(forKey: capturedProcessID)
+                    if isExec {
+                        if relativePath == rfmCurrentExecDir[capturedParentProcessID] {
+                            rfmCurrentExecDir.removeValue(forKey: capturedProcessID)
+                        } else {
+                            rfmCurrentExecDir[capturedProcessID] = relativePath
+                        }
                     } else {
-                        rfmCurrentDir[capturedProcessID] = relativePath
+                        if relativePath == rfmCurrentDir[capturedParentProcessID] {
+                            rfmCurrentDir.removeValue(forKey: capturedProcessID)
+                        } else {
+                            rfmCurrentDir[capturedProcessID] = relativePath
+                        }
                     }
                     errorCode = 0
-                    log += "OP_RFM_CHGDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0\n"
-                    print("OP_RFM_CHGDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0")
+                    let dirLabel = isExec ? "execDir" : "cwd"
+                    log += "OP_RFM_CHGDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), \(dirLabel)=\(relativePath)) -> 0\n"
+                    print("OP_RFM_CHGDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), \(dirLabel)=\(relativePath)) -> 0")
                 } else {
                     errorCode = 216  // E$PNNF — directory not found
                 }
@@ -1394,11 +1418,13 @@ public class DriveWireHost : Codable {
         var capturedPathNumber = 0
         var capturedProcessID = 0
         var capturedParentProcessID = 0
+        var capturedMode = 0
 
         if data.count >= expectedCount {
             capturedPathNumber = Int(data[0])
             capturedProcessID = Int(data[1])
             capturedParentProcessID = Int(data[2])
+            capturedMode = Int(data[3])
             result = expectedCount
             processor = OPRFMGETDELETEPATH
         }
@@ -1408,9 +1434,11 @@ public class DriveWireHost : Codable {
         func OPRFMGETDELETEPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let isExec = (capturedMode & 0x04) != 0
             let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
                                               processID: capturedProcessID,
-                                              parentProcessID: capturedParentProcessID)
+                                              parentProcessID: capturedParentProcessID,
+                                              isExec: isExec)
             var errorCode: UInt8 = 216
             if !pathname.isEmpty && !pathname.contains("\0") {
                 let localPath = (pathname as NSString).isAbsolutePath

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -107,48 +107,74 @@ public class DriveWireHost : Codable {
     
     struct RFMPathDescriptor {
         var processID = 0
+        var parentProcessID = 0
         var pathNumber = 0
         var pathDescriptorAddress = 0
         var mode = 0
         var filePosition = 0
         var pathname = ""
-        var shouldCreate = false
-        var pendingClose = false
         var localFile : FileHandle? = nil
         var fileContents : Data = Data()
         var attributes = [FileAttributeKey : Any]()
 
-        mutating func openLocalFile(rootPath: String) -> UInt8 {
+        mutating func openLocalFile(rootPath: String, shouldCreate: Bool = false) -> UInt8 {
             guard !pathname.isEmpty && !pathname.contains("\0") else { return 216 }
 
+            let expanded = RFMPathDescriptor.expandMultiDots(pathname)
             let localPathname: String
-            if (pathname as NSString).isAbsolutePath {
-                localPathname = rootPath + pathname
+            if (expanded as NSString).isAbsolutePath {
+                localPathname = rootPath + expanded
             } else {
-                localPathname = rootPath + "/" + pathname
+                localPathname = rootPath + "/" + expanded
             }
             let resolvedPath = URL(filePath: localPathname).standardized.path
             let normalizedRoot = URL(filePath: rootPath).standardized.path
             guard resolvedPath == normalizedRoot || resolvedPath.hasPrefix(normalizedRoot + "/") else {
-                return 214  // E$FNA
+                return 214  // E$FNA — escaped above rfmRootPath (or above device root)
             }
 
             do {
                 let fileExists = FileManager.default.fileExists(atPath: localPathname)
                 if mode & 0x80 != 0 {
-                    guard fileExists else { return 216 }
-                    attributes = try FileManager.default.attributesOfItem(atPath: localPathname)
-                    if let fileType = attributes[.type] as? FileAttributeType, fileType != .typeDirectory {
-                        return 214
+                    // Directory open — clamp '..' at the device root.
+                    let effectiveLocalPath: String
+                    if resolvedPath == normalizedRoot {
+                        // Resolved to rfmRootPath itself — not a valid CoCo device directory.
+                        // This happens when "." is opened with no CWD set (e.g. before any chd).
+                        return 216
+                    } else {
+                        effectiveLocalPath = resolvedPath
                     }
+                    var isDir: ObjCBool = false
+                    guard FileManager.default.fileExists(atPath: effectiveLocalPath, isDirectory: &isDir), isDir.boolValue else {
+                        return 216
+                    }
+                    attributes = (try? FileManager.default.attributesOfItem(atPath: effectiveLocalPath)) ?? [:]
+                    // Store the effective path so DriveWireHost can synthesize directory entries with proper LSNs.
+                    self.pathname = effectiveLocalPath.hasPrefix(rootPath)
+                        ? String(effectiveLocalPath.dropFirst(rootPath.count))
+                        : effectiveLocalPath
                 } else {
                     if !fileExists {
                         guard shouldCreate else { return 216 }
+                        // Check parent directory is writable before creating
+                        let parent = (localPathname as NSString).deletingLastPathComponent
+                        guard FileManager.default.isWritableFile(atPath: parent) else { return 214 }
                         guard FileManager.default.createFile(atPath: localPathname, contents: nil) else {
                             return 216
                         }
                     } else {
                         attributes = try FileManager.default.attributesOfItem(atPath: localPathname)
+                        if attributes[.type] as? FileAttributeType == .typeDirectory {
+                            return 214  // E$FNA — path is a directory, not a file
+                        }
+                        let needsWrite = (mode & 0x0A) != 0 || shouldCreate
+                        if needsWrite && !FileManager.default.isWritableFile(atPath: localPathname) {
+                            return 214  // E$FNA — write access denied
+                        }
+                        if !FileManager.default.isReadableFile(atPath: localPathname) {
+                            return 214  // E$FNA — read access denied
+                        }
                     }
                     let url = URL(filePath: localPathname)
                     let needsWrite = (mode & 0x0A) != 0 || shouldCreate
@@ -163,6 +189,75 @@ public class DriveWireHost : Codable {
                 return 216
             }
             return 0
+        }
+
+        // Build one 32-byte OS-9 directory entry: name[0..28] with last char | 0x80, then 3-byte LSN.
+        static func makeOS9DirEntry(_ name: String, lsn: Int) -> Data {
+            var entry = Data(repeating: 0, count: 32)
+            let bytes = Array(name.utf8.prefix(29))
+            for (i, b) in bytes.enumerated() {
+                entry[i] = i == bytes.count - 1 ? (b | 0x80) : b
+            }
+            entry[29] = UInt8((lsn >> 16) & 0xFF)
+            entry[30] = UInt8((lsn >> 8) & 0xFF)
+            entry[31] = UInt8(lsn & 0xFF)
+            return entry
+        }
+
+        // Expand OS-9 multi-dot path components: N dots = N-1 parent-dir references.
+        static func expandMultiDots(_ path: String) -> String {
+            return path.components(separatedBy: "/").map { c in
+                guard !c.isEmpty, c.allSatisfy({ $0 == "." }), c.count >= 2 else { return c }
+                return Array(repeating: "..", count: c.count - 1).joined(separator: "/")
+            }.joined(separator: "/")
+        }
+
+        // Synthesize an OS-9 file descriptor sector from host file attributes.
+        // Layout: FD.ATT(1) FD.OWN(2) FD.DAT(5) FD.LNK(1) FD.SIZ(4) FD.Creat(3) FD.SEG(zeros...)
+        func synthesizeFD(count: Int) -> Data {
+            var fd = Data(repeating: 0, count: max(count, 16))
+            let isDir = attributes[.type] as? FileAttributeType == .typeDirectory
+
+            // FD.ATT: DIR=0x80, owner R/W/E = 0x07, public R = 0x08
+            var att: UInt8 = isDir ? 0x8F : 0x0F
+            if let posix = attributes[.posixPermissions] as? Int {
+                att = isDir ? 0x80 : 0x00
+                if posix & 0o400 != 0 { att |= 0x01 }  // owner read
+                if posix & 0o200 != 0 { att |= 0x02 }  // owner write
+                if posix & 0o100 != 0 { att |= 0x04 }  // owner exec
+                if posix & 0o004 != 0 { att |= 0x08 }  // public read
+                if posix & 0o002 != 0 { att |= 0x10 }  // public write
+                if posix & 0o001 != 0 { att |= 0x20 }  // public exec
+            }
+            fd[0] = att
+
+            // FD.OWN (bytes 1-2): owner — 0
+            // FD.DAT (bytes 3-7): modification date YYMMDDHHMM
+            if let mod = attributes[.modificationDate] as? Date {
+                let c = Calendar.current
+                fd[3] = UInt8(max(0, min(255, c.component(.year, from: mod) - 1900)))
+                fd[4] = UInt8(c.component(.month, from: mod))
+                fd[5] = UInt8(c.component(.day, from: mod))
+                fd[6] = UInt8(c.component(.hour, from: mod))
+                fd[7] = UInt8(c.component(.minute, from: mod))
+            }
+            // FD.LNK (byte 8): link count
+            fd[8] = 1
+            // FD.SIZ (bytes 9-12): file size, big-endian
+            let sz = attributes[.size] as? Int ?? 0
+            fd[9]  = UInt8((sz >> 24) & 0xFF)
+            fd[10] = UInt8((sz >> 16) & 0xFF)
+            fd[11] = UInt8((sz >> 8) & 0xFF)
+            fd[12] = UInt8(sz & 0xFF)
+            // FD.Creat (bytes 13-15): creation date YYMMDD
+            if let cr = attributes[.creationDate] as? Date {
+                let c = Calendar.current
+                fd[13] = UInt8(max(0, min(255, c.component(.year, from: cr) - 1900)))
+                fd[14] = UInt8(c.component(.month, from: cr))
+                fd[15] = UInt8(c.component(.day, from: cr))
+            }
+            // FD.SEG (bytes 16+): segment list — all zeros for RFM (no physical sectors)
+            return Data(fd.prefix(count))
         }
 
         mutating func readLineFromFile(maximumCount: Int) -> (UInt8, Data) {
@@ -212,6 +307,12 @@ public class DriveWireHost : Codable {
 
     var rfmRootPath: String = NSHomeDirectory()
     private var rfmPaths: [Int: RFMPathDescriptor] = [:]
+    private var rfmCurrentDir: [Int: String] = [:]
+    // Maps host path ↔ unique LSN for synthesized RFM directory entries.
+    // LSNs start above a typical NitrOS-9 DW image (~524k sectors for DW format).
+    private var rfmLSNByPath: [String: Int] = [:]
+    private var rfmLSNToPath: [Int: String] = [:]
+    private var rfmLSNCounter: Int = 0x600000
     
     /// The no-operation transaction code.
     ///
@@ -420,8 +521,8 @@ public class DriveWireHost : Codable {
         dwTransaction.append(DWOp(opcode:OPNAMEOBJCREATE, processor: self.OP_NAMEOBJ_CREATE))
         dwTransaction.append(DWOp(opcode:OPNOP, processor: self.OP_NOP))
         dwTransaction.append(DWOp(opcode:OPTIME, processor: self.OP_TIME))
-        dwTransaction.append(DWOp(opcode:OPINIT, processor: self.OP_INIT))
-        dwTransaction.append(DWOp(opcode:OPTERM, processor: self.OP_TERM))
+        dwTransaction.append(DWOp(opcode:0x49, processor: self.OP_INIT))   // OPINIT (historical)
+        dwTransaction.append(DWOp(opcode:0x54, processor: self.OP_TERM))   // OPTERM (historical)
         dwTransaction.append(DWOp(opcode:OPREAD, processor: self.OP_READ))
         dwTransaction.append(DWOp(opcode:OPREADEX, processor: self.OP_READEX))
         dwTransaction.append(DWOp(opcode:OPREREAD, processor: self.OP_REREAD))
@@ -430,8 +531,8 @@ public class DriveWireHost : Codable {
         dwTransaction.append(DWOp(opcode:OPREWRITE, processor: self.OP_REWRITE))
         dwTransaction.append(DWOp(opcode:OPGETSTAT, processor: self.OP_GETSTAT))
         dwTransaction.append(DWOp(opcode:OPSETSTAT, processor: self.OP_SETSTAT))
-        dwTransaction.append(DWOp(opcode:OPRESET3, processor: self.OP_RESET))
-        dwTransaction.append(DWOp(opcode:OPRESET2, processor: self.OP_RESET))
+        dwTransaction.append(DWOp(opcode:0xF8, processor: self.OP_RESET))  // OPRESET3 (historical)
+        dwTransaction.append(DWOp(opcode:0xFE, processor: self.OP_RESET))  // OPRESET2 (historical)
         dwTransaction.append(DWOp(opcode:OPRESET, processor: self.OP_RESET))
         dwTransaction.append(DWOp(opcode:OPWIREBUG, processor: self.OP_WIREBUG))
         dwTransaction.append(DWOp(opcode:OPPRINTFLUSH, processor: self.OP_PRINTFLUSH))
@@ -576,6 +677,18 @@ public class DriveWireHost : Codable {
         processor = OP_OPCODE
         invalidateWatchdog()
     }
+
+    func resetRFMState() {
+        for descriptor in rfmPaths.values {
+            descriptor.localFile?.closeFile()
+        }
+        rfmPaths.removeAll()
+        rfmCurrentDir.removeAll()
+        rfmLSNByPath.removeAll()
+        rfmLSNToPath.removeAll()
+        rfmLSNCounter = 0x600000
+        print("RFM state reset")
+    }
     
     private func OP_DWINIT(data : Data) -> Int {
         var result = 0
@@ -704,23 +817,26 @@ public class DriveWireHost : Codable {
         resetState()
         delegate?.dataAvailable(host: self, data: Data([year, month, day, hour, minute, second]))
         delegate?.transactionCompleted(opCode: currentTransaction)
+        let msg = "OP_TIME -> \(1900 + Int(year))/\(month)/\(day) \(hour):\(String(format:"%02d",minute)):\(String(format:"%02d",second))"
+        log += msg + "\n"; print(msg)
         return 1
     }
-    
+
     private func OP_INIT(data : Data) -> Int {
-        currentTransaction = OPINIT
+        currentTransaction = 0x49   // OPINIT (historical)
         resetState()
-        statistics = DriveWireStatistics()  // reset statistics
+        statistics = DriveWireStatistics()
+        resetRFMState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        log = log + "OP_INIT" + "\n"
+        log += "OP_INIT\n"; print("OP_INIT")
         return 1
     }
-    
+
     private func OP_TERM(data : Data) -> Int {
-        currentTransaction = OPTERM
+        currentTransaction = 0x54   // OPTERM (historical)
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        log = log + "OP_TERM" + "\n"
+        log += "OP_TERM\n"; print("OP_TERM")
         return 1
     }
     
@@ -764,6 +880,8 @@ public class DriveWireHost : Codable {
             statistics.lastDriveNumber = driveNumber
             delegate?.dataAvailable(host: self, data: Data([UInt8(error)]))
             delegate?.transactionCompleted(opCode: currentTransaction)
+            let msg = "OP_WRITE(drive=\(driveNumber), lsn=0x\(String(vLSN, radix: 16))) -> \(error)"
+            log += msg + "\n"; print(msg)
         }
         
         return result
@@ -792,7 +910,8 @@ public class DriveWireHost : Codable {
             delegate?.transactionCompleted(opCode: currentTransaction)
         }
         
-        log = log + "OP_GETSTAT(" + String(statistics.lastDriveNumber) + "," + String(statistics.lastGetStat) + ")" + "\n"
+        log += "OP_GETSTAT(drive=\(statistics.lastDriveNumber), \(DriveWireHost.ssCodeName(Int(statistics.lastGetStat))))\n"
+        print("OP_GETSTAT(drive=\(statistics.lastDriveNumber), \(DriveWireHost.ssCodeName(Int(statistics.lastGetStat))))")
         return result
     }
     
@@ -810,15 +929,17 @@ public class DriveWireHost : Codable {
             delegate?.transactionCompleted(opCode: currentTransaction)
         }
         
-        log = log + "OP_SETSTAT(" + String(statistics.lastDriveNumber) + "," + String(statistics.lastGetStat) + ")" + "\n"
+        log += "OP_SETSTAT(drive=\(statistics.lastDriveNumber), \(DriveWireHost.ssCodeName(Int(statistics.lastSetStat))))\n"
+        print("OP_SETSTAT(drive=\(statistics.lastDriveNumber), \(DriveWireHost.ssCodeName(Int(statistics.lastSetStat))))")
         return result
     }
     
     private func OP_RESET(data : Data) -> Int {
         currentTransaction = OPRESET
         resetState()
+        resetRFMState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        log = log + "OP_RESET" + "\n"
+        log += "OP_RESET\n"; print("OP_RESET")
         return 1
     }
     
@@ -869,68 +990,83 @@ public class DriveWireHost : Codable {
     private func OP_SERINIT(data : Data) -> Int {
         currentTransaction = OPSERINIT
         guard data.count >= 2 else { return 0 }
+        let ch = data[1]
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 2  // opcode + channel#
+        let msg = "OP_SERINIT(ch=\(ch))"; log += msg + "\n"; print(msg)
+        return 2
     }
 
     private func OP_SERTERM(data : Data) -> Int {
         currentTransaction = OPSERTERM
         guard data.count >= 2 else { return 0 }
+        let ch = data[1]
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 2  // opcode + channel#
+        let msg = "OP_SERTERM(ch=\(ch))"; log += msg + "\n"; print(msg)
+        return 2
     }
 
     private func OP_SERREAD(data : Data) -> Int {
         currentTransaction = OPSERREAD
         guard data.count >= 2 else { return 0 }
+        let ch = data[1]
         resetState()
         delegate?.dataAvailable(host: self, data: Data([0x00, 0x00]))
-        return 2  // opcode + channel#
+        let msg = "OP_SERREAD(ch=\(ch))"; log += msg + "\n"; print(msg)
+        return 2
     }
 
     private func OP_SERREADM(data : Data) -> Int {
         currentTransaction = OPSERREADM
         guard data.count >= 2 else { return 0 }
+        let ch = data[1]
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 2  // opcode + channel#
+        let msg = "OP_SERREADM(ch=\(ch))"; log += msg + "\n"; print(msg)
+        return 2
     }
 
     private func OP_SERWRITE(data : Data) -> Int {
         currentTransaction = OPSERWRITE
         guard data.count >= 3 else { return 0 }
+        let ch = data[1]; let byte = data[2]
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 3  // opcode + channel# + data_byte
+        let msg = "OP_SERWRITE(ch=\(ch), byte=0x\(String(byte, radix: 16)))"; log += msg + "\n"; print(msg)
+        return 3
     }
 
     private func OP_SERWRITEM(data : Data) -> Int {
         currentTransaction = OPSERWRITEM
         guard data.count >= 3 else { return 0 }
-        let count = Int(data[2])
+        let ch = data[1]; let count = Int(data[2])
         let total = 3 + count
         guard data.count >= total else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return total  // opcode + channel# + count + data
+        let msg = "OP_SERWRITEM(ch=\(ch), bytes=\(count))"; log += msg + "\n"; print(msg)
+        return total
     }
 
     private func OP_SERGETSTAT(data : Data) -> Int {
         currentTransaction = OPSERGETSTAT
         guard data.count >= 3 else { return 0 }
+        let ch = data[1]; let code = data[2]
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 3  // opcode + channel# + stat_code
+        let msg = "OP_SERGETSTAT(ch=\(ch), \(DriveWireHost.ssCodeName(Int(code))))"; log += msg + "\n"; print(msg)
+        return 3
     }
 
     private func OP_SERSETSTAT(data : Data) -> Int {
         currentTransaction = OPSERSETSTAT
         guard data.count >= 3 else { return 0 }
+        let ch = data[1]; let code = data[2]
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 3  // opcode + channel# + setstat_code
+        let msg = "OP_SERSETSTAT(ch=\(ch), \(DriveWireHost.ssCodeName(Int(code))))"; log += msg + "\n"; print(msg)
+        return 3
     }
 
     private func OP_FASTWRITE_Serial(data : Data) -> Int {
@@ -1002,7 +1138,7 @@ public class DriveWireHost : Codable {
 
     private func rfmOpen(data: Data, shouldCreate: Bool) -> Int {
         var result = 0
-        let expectedCount = 3
+        let expectedCount = 4
         var capturedPathNumber = 0
 
         if data.count >= expectedCount {
@@ -1010,8 +1146,8 @@ public class DriveWireHost : Codable {
             var descriptor = RFMPathDescriptor()
             descriptor.pathNumber = capturedPathNumber
             descriptor.processID = Int(data[1])
-            descriptor.mode = Int(data[2])
-            descriptor.shouldCreate = shouldCreate
+            descriptor.parentProcessID = Int(data[2])
+            descriptor.mode = Int(data[3])
             rfmPaths[capturedPathNumber] = descriptor
             result = expectedCount
             processor = OPRFMGETPATH
@@ -1022,23 +1158,142 @@ public class DriveWireHost : Codable {
         func OPRFMGETPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
-            let pathname = String(bytes: pathBytes, encoding: .ascii) ?? ""
+            let pid = rfmPaths[capturedPathNumber]?.processID ?? 0
+            let ppid = rfmPaths[capturedPathNumber]?.parentProcessID ?? 0
+            let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
+                                              processID: pid, parentProcessID: ppid)
             rfmPaths[capturedPathNumber]?.pathname = pathname
-            let errorCode = rfmPaths[capturedPathNumber]?.openLocalFile(rootPath: rfmRootPath) ?? 0xFF
+            let errorCode = rfmPaths[capturedPathNumber]?.openLocalFile(rootPath: rfmRootPath, shouldCreate: shouldCreate) ?? 0xFF
+            if errorCode != 0 {
+                // Failed open — remove the descriptor so the slot is clean for reuse.
+                rfmPaths.removeValue(forKey: capturedPathNumber)
+            }
+            // For directory opens, synthesize OS-9 directory entries with stable LSNs.
+            if errorCode == 0, let descriptor = rfmPaths[capturedPathNumber], descriptor.mode & 0x80 != 0 {
+                rfmPaths[capturedPathNumber]?.fileContents = synthesizeDirectoryEntries(for: descriptor)
+            }
             delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            log += "OP_RFM_\(shouldCreate ? "CREATE" : "OPEN")(\(capturedPathNumber), \(pathname)) -> \(errorCode)\n"
+            let msg = "OP_RFM_\(shouldCreate ? "CREATE" : "OPEN")(path#\(capturedPathNumber), pid=\(pid), ppid=\(ppid), mode=0x\(String(rfmPaths[capturedPathNumber]?.mode ?? 0, radix: 16)), cwd=\(rfmCurrentDir[pid] ?? rfmCurrentDir[ppid] ?? "none"), resolved=\(pathname)) -> \(errorCode)"
+            log += msg + "\n"
+            print(msg)
             resetState()
             return crOffset - data.startIndex + 1
         }
     }
 
+    private func resolveRFMPathname(_ pathname: String, processID: Int, parentProcessID: Int) -> String {
+        guard !(pathname as NSString).isAbsolutePath else { return pathname }
+        let base: String
+        if let cwd = rfmCurrentDir[processID] {
+            base = cwd
+        } else if let cwd = rfmCurrentDir[parentProcessID] {
+            base = cwd
+        } else {
+            return pathname
+        }
+        if pathname == "." { return base }
+        return (base as NSString).appendingPathComponent(pathname)
+    }
+
+    // Expand OS-9 multi-dot path components: N dots = N-1 parent-dir references.
+    private func expandOS9MultiDots(_ path: String) -> String {
+        RFMPathDescriptor.expandMultiDots(path)
+    }
+
+    private static func ssCodeName(_ code: Int) -> String {
+        switch code {
+        case 0x00: return "SS.Opt"
+        case 0x01: return "SS.Ready"
+        case 0x02: return "SS.Size"
+        case 0x03: return "SS.Reset"
+        case 0x04: return "SS.WTrk"
+        case 0x05: return "SS.Pos"
+        case 0x06: return "SS.EOF"
+        case 0x07: return "SS.Link"
+        case 0x08: return "SS.ULink"
+        case 0x09: return "SS.Feed"
+        case 0x0A: return "SS.Frz"
+        case 0x0B: return "SS.SPT"
+        case 0x0C: return "SS.SQD"
+        case 0x0D: return "SS.DCmd"
+        case 0x0E: return "SS.DevNm"
+        case 0x0F: return "SS.FD"
+        case 0x10: return "SS.Ticks"
+        case 0x11: return "SS.Lock"
+        case 0x12: return "SS.DStat"
+        case 0x13: return "SS.Joy"
+        case 0x14: return "SS.BlkRd"
+        case 0x15: return "SS.BlkWr"
+        case 0x16: return "SS.Reten"
+        case 0x17: return "SS.WFM"
+        case 0x18: return "SS.RFM"
+        case 0x19: return "SS.ELog"
+        case 0x1A: return "SS.SSig"
+        case 0x1B: return "SS.Relea"
+        case 0x1C: return "SS.AlfaS"
+        case 0x1D: return "SS.Break"
+        case 0x1E: return "SS.RsBit"
+        case 0x1F: return "SS.DirEnt"
+        case 0x20: return "SS.FDInf"
+        case 0x21: return "SS.Cursr"
+        case 0x22: return "SS.ScSiz"
+        case 0x23: return "SS.KySns"
+        case 0x24: return "SS.ComSt"
+        case 0x25: return "SS.Open"
+        case 0x26: return "SS.Close"
+        case 0x27: return "SS.HngUp"
+        case 0x28: return "SS.FSig"
+        default:   return "0x\(String(code, radix: 16, uppercase: false))"
+        }
+    }
+
+    // Returns a stable LSN for the given absolute host path, allocating a new one if needed.
+    private func lsnForPath(_ path: String) -> Int {
+        if let existing = rfmLSNByPath[path] { return existing }
+        let lsn = rfmLSNCounter
+        rfmLSNByPath[path] = lsn
+        rfmLSNToPath[lsn] = path
+        rfmLSNCounter += 1
+        return lsn
+    }
+
+    // Builds OS-9 directory contents for the open directory descriptor, registering each entry in the LSN map.
+    private func synthesizeDirectoryEntries(for descriptor: RFMPathDescriptor) -> Data {
+        let dirPath = rfmRootPath + descriptor.pathname
+        var entries = Data()
+
+        // '..' and '.' entries — point to parent and self
+        let parentPath: String
+        let selfPath = (URL(fileURLWithPath: dirPath).standardized.path)
+        let deviceRoot = rfmRootPath + "/" + (descriptor.pathname.split(separator: "/").first.map(String.init) ?? "")
+        if selfPath == URL(fileURLWithPath: deviceRoot).standardized.path {
+            parentPath = selfPath   // at device root: '..' loops back to self
+        } else {
+            parentPath = URL(fileURLWithPath: dirPath + "/..").standardized.path
+        }
+        entries.append(contentsOf: RFMPathDescriptor.makeOS9DirEntry("..", lsn: lsnForPath(parentPath)))
+        entries.append(contentsOf: RFMPathDescriptor.makeOS9DirEntry(".",  lsn: lsnForPath(selfPath)))
+
+        if let contents = try? FileManager.default.contentsOfDirectory(atPath: dirPath) {
+            for name in contents.sorted() {
+                let childPath = dirPath + "/" + name
+                entries.append(contentsOf: RFMPathDescriptor.makeOS9DirEntry(name, lsn: lsnForPath(childPath)))
+            }
+        }
+        return entries
+    }
+
     private func OPRFMMAKDIR(data: Data) -> Int {
         var result = 0
-        let expectedCount = 3
+        let expectedCount = 4
         var capturedPathNumber = 0
+        var capturedProcessID = 0
+        var capturedParentProcessID = 0
 
         if data.count >= expectedCount {
             capturedPathNumber = Int(data[0])
+            capturedProcessID = Int(data[1])
+            capturedParentProcessID = Int(data[2])
             result = expectedCount
             processor = OPRFMGETMKDIRPATH
         }
@@ -1048,7 +1303,9 @@ public class DriveWireHost : Codable {
         func OPRFMGETMKDIRPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
-            let pathname = String(bytes: pathBytes, encoding: .ascii) ?? ""
+            let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
+                                              processID: capturedProcessID,
+                                              parentProcessID: capturedParentProcessID)
             var errorCode: UInt8 = 216
             if !pathname.isEmpty && !pathname.contains("\0") {
                 let localPath = (pathname as NSString).isAbsolutePath
@@ -1060,7 +1317,8 @@ public class DriveWireHost : Codable {
                         try FileManager.default.createDirectory(
                             atPath: resolved, withIntermediateDirectories: true)
                         errorCode = 0
-                        log += "OP_RFM_MAKDIR(\(capturedPathNumber), \(pathname)) -> 0\n"
+                        log += "OP_RFM_MAKDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0\n"
+                        print("OP_RFM_MAKDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0")
                     } catch { errorCode = 216 }
                 } else { errorCode = 214 }
             }
@@ -1071,18 +1329,76 @@ public class DriveWireHost : Codable {
     }
 
     private func OPRFMCHGDIR(data: Data) -> Int {
-        // rfm.asm chgdir uses sendit — only the sub-opcode is sent, no path data.
-        resetState()
-        return 0
+        var result = 0
+        let expectedCount = 4
+        var capturedPathNumber = 0
+        var capturedProcessID = 0
+        var capturedParentProcessID = 0
+
+        if data.count >= expectedCount {
+            capturedPathNumber = Int(data[0])
+            capturedProcessID = Int(data[1])
+            capturedParentProcessID = Int(data[2])
+            result = expectedCount
+            processor = OPRFMGETCHGDIRPATH
+        }
+
+        return result
+
+        func OPRFMGETCHGDIRPATH(data: Data) -> Int {
+            guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
+            let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
+                                              processID: capturedProcessID,
+                                              parentProcessID: capturedParentProcessID)
+            let expandedPathname = expandOS9MultiDots(pathname)
+            var errorCode: UInt8 = 216
+            if !expandedPathname.isEmpty && !expandedPathname.contains("\0") {
+                let localPath = (expandedPathname as NSString).isAbsolutePath
+                    ? rfmRootPath + expandedPathname : rfmRootPath + "/" + expandedPathname
+                let resolved = URL(filePath: localPath).standardized.path
+                let normalizedRoot = URL(filePath: rfmRootPath).standardized.path
+                // Accept paths within rfmRootPath, OR above it (will be clamped to device root).
+                let deviceRoot = "/" + (expandedPathname.split(separator: "/").first.map(String.init) ?? "")
+                let effectiveResolved = (resolved == normalizedRoot || resolved.hasPrefix(normalizedRoot + "/"))
+                    ? resolved : normalizedRoot + deviceRoot
+                var isDir: ObjCBool = false
+                if FileManager.default.fileExists(atPath: effectiveResolved, isDirectory: &isDir), isDir.boolValue {
+                    var relativePath = String(effectiveResolved.dropFirst(normalizedRoot.count))
+                    if relativePath.isEmpty { relativePath = deviceRoot }
+                    // Only store this process's CWD when it differs from the parent's.
+                    // If it matches, remove any stale entry so the parent lookup always wins.
+                    // This prevents a child's chgdir(".") from caching a value that would
+                    // hide a subsequent chd by the parent.
+                    if relativePath == rfmCurrentDir[capturedParentProcessID] {
+                        rfmCurrentDir.removeValue(forKey: capturedProcessID)
+                    } else {
+                        rfmCurrentDir[capturedProcessID] = relativePath
+                    }
+                    errorCode = 0
+                    log += "OP_RFM_CHGDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0\n"
+                    print("OP_RFM_CHGDIR(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0")
+                } else {
+                    errorCode = 216  // E$PNNF — directory not found
+                }
+            }
+            delegate?.dataAvailable(host: self, data: Data([errorCode]))
+            resetState()
+            return crOffset - data.startIndex + 1
+        }
     }
 
     private func OPRFMDELETE(data: Data) -> Int {
         var result = 0
-        let expectedCount = 3
+        let expectedCount = 4
         var capturedPathNumber = 0
+        var capturedProcessID = 0
+        var capturedParentProcessID = 0
 
         if data.count >= expectedCount {
             capturedPathNumber = Int(data[0])
+            capturedProcessID = Int(data[1])
+            capturedParentProcessID = Int(data[2])
             result = expectedCount
             processor = OPRFMGETDELETEPATH
         }
@@ -1092,7 +1408,9 @@ public class DriveWireHost : Codable {
         func OPRFMGETDELETEPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
             let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
-            let pathname = String(bytes: pathBytes, encoding: .ascii) ?? ""
+            let pathname = resolveRFMPathname(String(bytes: pathBytes, encoding: .ascii) ?? "",
+                                              processID: capturedProcessID,
+                                              parentProcessID: capturedParentProcessID)
             var errorCode: UInt8 = 216
             if !pathname.isEmpty && !pathname.contains("\0") {
                 let localPath = (pathname as NSString).isAbsolutePath
@@ -1116,7 +1434,8 @@ public class DriveWireHost : Codable {
                             errorCode = 0
                         }
                         if errorCode == 0 {
-                            log += "OP_RFM_DELETE(\(capturedPathNumber), \(pathname)) -> 0\n"
+                            log += "OP_RFM_DELETE(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0\n"
+                        print("OP_RFM_DELETE(path#\(capturedPathNumber), pid=\(capturedProcessID), ppid=\(capturedParentProcessID), path=\(pathname)) -> 0")
                         }
                     } catch { errorCode = 216 }
                 } else { errorCode = 214 }
@@ -1132,7 +1451,7 @@ public class DriveWireHost : Codable {
     private func OPRFMSEEK(data: Data) -> Int {
         var result = 0
         let expectedCount = 5
-        var errorCode: UInt8 = 0
+        let errorCode: UInt8 = 0
 
         if data.count >= expectedCount {
             let pathNumber = Int(data[0])
@@ -1141,7 +1460,8 @@ public class DriveWireHost : Codable {
             result = expectedCount
             resetState()
             delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            log += "OP_RFM_SEEK(\(pathNumber), \(position)) -> \(errorCode)\n"
+            log += "OP_RFM_SEEK(path#\(pathNumber), pos=\(position)) -> \(errorCode)\n"
+            print("OP_RFM_SEEK(path#\(pathNumber), pos=\(position)) -> \(errorCode)")
         }
 
         return result
@@ -1155,22 +1475,25 @@ public class DriveWireHost : Codable {
 
         if data.count >= expectedCount {
             let pathNumber = Int(data[0])
-            let maxBytes = min(Int(data[1]) * 256 + Int(data[2]), 255)
+            let maxBytes = Int(data[1]) * 256 + Int(data[2])
             result = expectedCount
 
             if var descriptor = rfmPaths[pathNumber] {
                 let (errorCode, lineData) = descriptor.readFromFile(maximumCount: maxBytes)
                 rfmPaths[pathNumber] = descriptor
+                let ec = errorCode != 0 ? Int(errorCode) : Int(lineData.count)
+                log += "OP_RFM_READ(path#\(pathNumber), max=\(maxBytes)) -> \(ec)\n"
+                print("OP_RFM_READ(path#\(pathNumber), max=\(maxBytes)) -> \(ec)")
                 if errorCode != 0 {
-                    delegate?.dataAvailable(host: self, data: Data([0x00]))
+                    delegate?.dataAvailable(host: self, data: Data([0x00, 0x00]))
                 } else {
-                    delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count)]))
+                    delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count >> 8), UInt8(lineData.count & 0xFF)]))
                     if !lineData.isEmpty {
                         delegate?.dataAvailable(host: self, data: lineData)
                     }
                 }
             } else {
-                delegate?.dataAvailable(host: self, data: Data([0x00]))
+                delegate?.dataAvailable(host: self, data: Data([0x00, 0x00]))
             }
             resetState()
         }
@@ -1195,6 +1518,8 @@ public class DriveWireHost : Codable {
                     _ = descriptor.writeToFile(data: Data(data[headerCount..<totalCount]))
                     rfmPaths[k] = descriptor
                 }
+                log += "OP_RFM_WRITE(path#\(pathNumber), bytes=\(byteCount))\n"
+                print("OP_RFM_WRITE(path#\(pathNumber), bytes=\(byteCount))")
                 result = totalCount
                 resetState()
             }
@@ -1210,22 +1535,25 @@ public class DriveWireHost : Codable {
 
         if data.count >= expectedCount {
             let pathNumber = Int(data[0])
-            let maxBytes = min(Int(data[1]) * 256 + Int(data[2]), 255)
+            let maxBytes = Int(data[1]) * 256 + Int(data[2])
             result = expectedCount
 
             if var descriptor = rfmPaths[pathNumber] {
                 let (errorCode, lineData) = descriptor.readLineFromFile(maximumCount: maxBytes)
                 rfmPaths[pathNumber] = descriptor
+                let ec = errorCode != 0 ? Int(errorCode) : Int(lineData.count)
+                log += "OP_RFM_READLN(path#\(pathNumber), max=\(maxBytes)) -> \(ec)\n"
+                print("OP_RFM_READLN(path#\(pathNumber), max=\(maxBytes)) -> \(ec)")
                 if errorCode != 0 {
-                    delegate?.dataAvailable(host: self, data: Data([0x00]))
+                    delegate?.dataAvailable(host: self, data: Data([0x00, 0x00]))
                 } else {
-                    delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count)]))
+                    delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count >> 8), UInt8(lineData.count & 0xFF)]))
                     if !lineData.isEmpty {
                         delegate?.dataAvailable(host: self, data: lineData)
                     }
                 }
             } else {
-                delegate?.dataAvailable(host: self, data: Data([0x00]))
+                delegate?.dataAvailable(host: self, data: Data([0x00, 0x00]))
             }
             resetState()
         }
@@ -1249,6 +1577,8 @@ public class DriveWireHost : Codable {
                     _ = descriptor.writeToFile(data: Data(data[headerCount..<totalCount]), translateCR: true)
                     rfmPaths[k] = descriptor
                 }
+                log += "OP_RFM_WRITLN(path#\(pathNumber), bytes=\(byteCount))\n"
+                print("OP_RFM_WRITLN(path#\(pathNumber), bytes=\(byteCount))")
                 result = totalCount
                 resetState()
             }
@@ -1257,24 +1587,85 @@ public class DriveWireHost : Codable {
         return result
     }
 
-    // Receives: path#(1) + SS.code(1). rfm.asm's getstt handlers are stubs, so send nothing.
+    // Receives: path#(1) + SS.code(1). SS.FD additionally receives 2-byte count then sends FD.
     private func OPRFMGETSTT(data: Data) -> Int {
         var result = 0
         let expectedCount = 2
+        var capturedPathNumber = 0
 
         if data.count >= expectedCount {
-            let pathNumber = Int(data[0])
+            capturedPathNumber = Int(data[0])
             let statCode = Int(data[1])
             result = expectedCount
-            resetState()
-            log += "OP_RFM_GETSTT(\(pathNumber), \(statCode))\n"
+            log += "OP_RFM_GETSTT(path#\(capturedPathNumber), \(DriveWireHost.ssCodeName(statCode)))\n"
+            print("OP_RFM_GETSTT(path#\(capturedPathNumber), \(DriveWireHost.ssCodeName(statCode)))")
+            if statCode == 0x02 {  // SS.Size — send 4-byte file size
+                let size = rfmPaths[capturedPathNumber]?.fileContents.count ?? 0
+                let msg = "OP_RFM_GETSTT(path#\(capturedPathNumber), SS.Size) -> \(size)"
+                log += msg + "\n"; print(msg)
+                delegate?.dataAvailable(host: self, data: Data([
+                    UInt8((size >> 24) & 0xFF), UInt8((size >> 16) & 0xFF),
+                    UInt8((size >> 8) & 0xFF),  UInt8(size & 0xFF)]))
+                resetState()
+            } else if statCode == 0x05 {  // SS.Pos — send 4-byte current position
+                let pos = rfmPaths[capturedPathNumber]?.filePosition ?? 0
+                let msg = "OP_RFM_GETSTT(path#\(capturedPathNumber), SS.Pos) -> \(pos)"
+                log += msg + "\n"; print(msg)
+                delegate?.dataAvailable(host: self, data: Data([
+                    UInt8((pos >> 24) & 0xFF), UInt8((pos >> 16) & 0xFF),
+                    UInt8((pos >> 8) & 0xFF),  UInt8(pos & 0xFF)]))
+                resetState()
+            } else if statCode == 0x06 {  // SS.EOF — send 0 (not EOF) or E$EOF (211)
+                let isEOF = rfmPaths[capturedPathNumber].map { $0.filePosition >= $0.fileContents.count } ?? true
+                let response: UInt8 = isEOF ? 211 : 0
+                let msg = "OP_RFM_GETSTT(path#\(capturedPathNumber), SS.EOF) -> \(isEOF ? "EOF" : "OK")"
+                log += msg + "\n"; print(msg)
+                delegate?.dataAvailable(host: self, data: Data([response]))
+                resetState()
+            } else if statCode == 0x0F {  // SS.FD
+                processor = OPRFMGETSSFD
+            } else if statCode == 0x20 {  // SS.FDInf
+                processor = OPRFMGETSSFDINF
+            } else {
+                resetState()
+            }
         }
 
         return result
+
+        func OPRFMGETSSFD(data: Data) -> Int {
+            guard data.count >= 2 else { return 0 }
+            let count = min(Int(data[0]) * 256 + Int(data[1]), 256)
+            let fd = rfmPaths[capturedPathNumber]?.synthesizeFD(count: count)
+                ?? Data(repeating: 0, count: count)
+            delegate?.dataAvailable(host: self, data: fd)
+            log += "OP_RFM_GETSTT_FD(path#\(capturedPathNumber), bytes=\(count))\n"
+            print("OP_RFM_GETSTT_FD(path#\(capturedPathNumber), bytes=\(count))")
+            resetState()
+            return 2
+        }
+
+        func OPRFMGETSSFDINF(data: Data) -> Int {
+            guard data.count >= 4 else { return 0 }
+            // data[0]=Y_hi=LSN[0], data[1]=Y_lo=length, data[2]=U_hi=LSN[1], data[3]=U_lo=LSN[2]
+            let lsn = Int(data[0]) << 16 | Int(data[2]) << 8 | Int(data[3])
+            var tempDesc = RFMPathDescriptor()
+            if let hostPath = rfmLSNToPath[lsn] {
+                tempDesc.attributes = (try? FileManager.default.attributesOfItem(atPath: hostPath)) ?? [:]
+            }
+            let fd = tempDesc.synthesizeFD(count: 256)
+            delegate?.dataAvailable(host: self, data: fd)
+            let path = rfmLSNToPath[lsn] ?? "unknown"
+            log += "OP_RFM_GETSTT_FDInf(lsn=0x\(String(lsn, radix: 16)), path=\(path))\n"
+            print("OP_RFM_GETSTT_FDInf(lsn=0x\(String(lsn, radix: 16)), path=\(path))")
+            resetState()
+            return 4
+        }
     }
 
     // Receives nothing (rfm.asm sendit only sends the sub-op). No response.
     private func OPRFMSETSTT(data: Data) -> Int {
+        print("OP_RFM_SETSTT")
         resetState()
         return 0
     }
@@ -1289,17 +1680,13 @@ public class DriveWireHost : Codable {
 
         if data.count >= expectedCount {
             let pathNumber = Int(data[0])
-            if let descriptor = rfmPaths[pathNumber], descriptor.shouldCreate && !descriptor.pendingClose {
-                // First close of a CREATE'd path — stay open for child writes
-                rfmPaths[pathNumber]?.pendingClose = true
-            } else {
-                rfmPaths[pathNumber]?.localFile?.closeFile()
-                rfmPaths.removeValue(forKey: pathNumber)
-            }
+            rfmPaths[pathNumber]?.localFile?.closeFile()
+            rfmPaths.removeValue(forKey: pathNumber)
             result = expectedCount
             delegate?.dataAvailable(host: self, data: Data([0x00]))
             resetState()
-            log += "OP_RFM_CLOSE(\(pathNumber))\n"
+            log += "OP_RFM_CLOSE(path#\(pathNumber))\n"
+            print("OP_RFM_CLOSE(path#\(pathNumber))")
         }
 
         return result
@@ -1397,7 +1784,8 @@ extension DriveWireHost {
                 
                 // Send the response code to the guest.
                 delegate?.dataAvailable(host: self, data: Data([UInt8(error)]))
-                
+                let msg = "OP_READEX(drive=\(statistics.lastDriveNumber), lsn=0x\(String(statistics.lastLSN, radix: 16))) -> \(error)"
+                log += msg + "\n"; print(msg)
                 // Reset the state machine.
                 resetState()
             }
@@ -1426,9 +1814,13 @@ extension DriveWireHost {
 
             // We read 5 bytes into this buffer (OP_READEX, 1 byte drive number, 3 byte LSN)
             result = 5;
-            
-            // Check if the drive number exists in our virtual drive list.
-            if let virtualDrive = virtualDrives.first(where: { $0.driveNumber == driveNumber }) {
+
+            // Check if this LSN belongs to a synthesized RFM file descriptor.
+            if let hostPath = rfmLSNToPath[vLSN] {
+                var tempDesc = RFMPathDescriptor()
+                tempDesc.attributes = (try? FileManager.default.attributesOfItem(atPath: hostPath)) ?? [:]
+                sectorBuffer = tempDesc.synthesizeFD(count: 256)
+            } else if let virtualDrive = virtualDrives.first(where: { $0.driveNumber == driveNumber }) {
                 // It exists! Read sector from disk image.
                 statistics.lastDriveNumber = driveNumber
                 statistics.readCount = statistics.readCount + 1
@@ -1438,8 +1830,6 @@ extension DriveWireHost {
                 // It doesn't exist. Set the error code.
                 error = DriveWireProtocolError.E_UNIT.rawValue
             }
-
-            // Send the error code
             delegate?.dataAvailable(host: self, data: Data([UInt8(error)]))
             
             // If we have an OK response, we send the sector and checksum.

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1099,9 +1099,14 @@ public class DriveWireHost : Codable {
                 let normalizedRoot = URL(filePath: rfmRootPath).standardized.path
                 if resolved == normalizedRoot || resolved.hasPrefix(normalizedRoot + "/") {
                     do {
-                        try FileManager.default.removeItem(atPath: resolved)
-                        errorCode = 0
-                        log += "OP_RFM_DELETE(\(capturedPathNumber), \(pathname)) -> 0\n"
+                        let attrs = try FileManager.default.attributesOfItem(atPath: resolved)
+                        if attrs[.type] as? FileAttributeType == .typeDirectory {
+                            errorCode = 214  // E$FNA — use deldir for directories
+                        } else {
+                            try FileManager.default.removeItem(atPath: resolved)
+                            errorCode = 0
+                            log += "OP_RFM_DELETE(\(capturedPathNumber), \(pathname)) -> 0\n"
+                        }
                     } catch { errorCode = 216 }
                 } else { errorCode = 214 }
             }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -845,60 +845,71 @@ public class DriveWireHost : Codable {
     
     private func OP_SERINIT(data : Data) -> Int {
         currentTransaction = OPSERINIT
+        guard data.count >= 2 else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return 2  // opcode + channel#
     }
-    
+
     private func OP_SERTERM(data : Data) -> Int {
         currentTransaction = OPSERTERM
+        guard data.count >= 2 else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return 2  // opcode + channel#
     }
-    
+
     private func OP_SERREAD(data : Data) -> Int {
         currentTransaction = OPSERREAD
+        guard data.count >= 2 else { return 0 }
         resetState()
         delegate?.dataAvailable(host: self, data: Data([0x00, 0x00]))
-        return 1
+        return 2  // opcode + channel#
     }
-    
+
     private func OP_SERREADM(data : Data) -> Int {
         currentTransaction = OPSERREADM
+        guard data.count >= 2 else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return 2  // opcode + channel#
     }
-    
+
     private func OP_SERWRITE(data : Data) -> Int {
         currentTransaction = OPSERWRITE
+        guard data.count >= 3 else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return 3  // opcode + channel# + data_byte
     }
-    
+
     private func OP_SERWRITEM(data : Data) -> Int {
         currentTransaction = OPSERWRITEM
+        guard data.count >= 3 else { return 0 }
+        let count = Int(data[2])
+        let total = 3 + count
+        guard data.count >= total else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return total  // opcode + channel# + count + data
     }
-    
+
     private func OP_SERGETSTAT(data : Data) -> Int {
         currentTransaction = OPSERGETSTAT
+        guard data.count >= 3 else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return 3  // opcode + channel# + stat_code
     }
-    
+
     private func OP_SERSETSTAT(data : Data) -> Int {
         currentTransaction = OPSERSETSTAT
+        guard data.count >= 3 else { return 0 }
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)
-        return 1
+        return 3  // opcode + channel# + setstat_code
     }
-    
+
     private func OP_FASTWRITE_Serial(data : Data) -> Int {
         resetState()
         delegate?.transactionCompleted(opCode: currentTransaction)

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -1489,6 +1489,7 @@ public class DriveWireHost : Codable {
                 } else {
                     delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count >> 8), UInt8(lineData.count & 0xFF)]))
                     if !lineData.isEmpty {
+                        Thread.sleep(forTimeInterval: 0.002)
                         delegate?.dataAvailable(host: self, data: lineData)
                     }
                 }
@@ -1549,6 +1550,7 @@ public class DriveWireHost : Codable {
                 } else {
                     delegate?.dataAvailable(host: self, data: Data([UInt8(lineData.count >> 8), UInt8(lineData.count & 0xFF)]))
                     if !lineData.isEmpty {
+                        Thread.sleep(forTimeInterval: 0.002)
                         delegate?.dataAvailable(host: self, data: lineData)
                     }
                 }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -190,13 +190,15 @@ public class DriveWireHost : Codable {
             guard let file = localFile else { return 216 }
             let bytesToWrite: Data
             if translateCR {
-                // Strip $FF padding (OS-9 string terminator) and convert CR→LF
-                var out = Data()
-                for byte in data {
-                    if byte == 0xFF { break }
-                    out.append(byte == 0x0D ? 0x0A : byte)
+                // Strip trailing $FF and $00 padding, convert all $0D → $0A
+                var endIndex = data.endIndex
+                while endIndex > data.startIndex {
+                    let prev = data.index(before: endIndex)
+                    let byte = data[prev]
+                    if byte != 0x00 && byte != 0xFF { break }
+                    endIndex = prev
                 }
-                bytesToWrite = out
+                bytesToWrite = Data(data[data.startIndex..<endIndex].map { $0 == 0x0D ? 0x0A : $0 })
             } else {
                 bytesToWrite = data
             }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -105,38 +105,63 @@ public class DriveWireHost : Codable {
     private var processor : ((Data) -> Int)?
     
     struct RFMPathDescriptor {
+        var processID = 0
         var pathNumber = 0
+        var pathDescriptorAddress = 0
         var mode = 0
         var filePosition = 0
         var pathname = ""
+        var shouldCreate = false
         var localFile : FileHandle? = nil
         var fileContents : Data = Data()
         var attributes = [FileAttributeKey : Any]()
 
         mutating func openLocalFile(rootPath: String) -> UInt8 {
-            var errorCode : UInt8 = 0
             let localPathname: String
             if (pathname as NSString).isAbsolutePath {
                 localPathname = rootPath + pathname
             } else {
                 localPathname = rootPath + "/" + pathname
             }
+
+            // Guard against path traversal escaping rfmRootPath.
+            guard !pathname.isEmpty else { return 216 }
+            let resolvedPath = URL(filePath: localPathname).standardized.path
+            let normalizedRoot = URL(filePath: rootPath).standardized.path
+            guard resolvedPath == normalizedRoot || resolvedPath.hasPrefix(normalizedRoot + "/") else {
+                return 214  // E$FNA
+            }
+
             do {
-                attributes = try FileManager.default.attributesOfItem(atPath: localPathname)
+                let fileExists = FileManager.default.fileExists(atPath: localPathname)
                 if mode & 0x80 != 0 {
+                    guard fileExists else { return 216 }
+                    attributes = try FileManager.default.attributesOfItem(atPath: localPathname)
                     if let fileType = attributes[.type] as? FileAttributeType, fileType != .typeDirectory {
-                        errorCode = 214
+                        return 214
                     }
                 } else {
-                    localFile = try FileHandle(forReadingFrom: URL(filePath: localPathname))
-                    if let localFile = localFile {
-                        fileContents = localFile.availableData
+                    if !fileExists {
+                        guard shouldCreate else { return 216 }
+                        guard FileManager.default.createFile(atPath: localPathname, contents: nil) else {
+                            return 216
+                        }
+                    } else {
+                        attributes = try FileManager.default.attributesOfItem(atPath: localPathname)
+                    }
+                    let url = URL(filePath: localPathname)
+                    let needsWrite = (mode & 0x0A) != 0 || shouldCreate
+                    localFile = needsWrite
+                        ? try FileHandle(forUpdating: url)
+                        : try FileHandle(forReadingFrom: url)
+                    if let f = localFile {
+                        fileContents = f.availableData
                     }
                 }
             } catch {
-                errorCode = 216
+                return 216
             }
-            return errorCode
+            return 0
         }
 
         mutating func readLineFromFile(offset : Int, maximumCount : Int) -> (UInt8, Data) {
@@ -956,22 +981,27 @@ public class DriveWireHost : Codable {
     }
     
     private func OPRFMCREATE(data : Data) -> Int {
-        // Create is handled identically to Open on the host side.
-        return OPRFMOPEN(data: data)
+        return rfmOpen(data: data, shouldCreate: true)
     }
 
-    // Receives: path#(1) + mode(1), then pathname terminated by CR ($0D).
+    // Receives: path#(1) + processID(1) + mode(1), then pathname terminated by CR ($0D).
     // Sends back: 1-byte error code.
     private func OPRFMOPEN(data : Data) -> Int {
+        return rfmOpen(data: data, shouldCreate: false)
+    }
+
+    private func rfmOpen(data: Data, shouldCreate: Bool) -> Int {
         var result = 0
-        let expectedCount = 2
+        let expectedCount = 3
         var capturedPathNumber = 0
 
         if data.count >= expectedCount {
             capturedPathNumber = Int(data[0])
             var descriptor = RFMPathDescriptor()
             descriptor.pathNumber = capturedPathNumber
-            descriptor.mode = Int(data[1])
+            descriptor.processID = Int(data[1])
+            descriptor.mode = Int(data[2])
+            descriptor.shouldCreate = shouldCreate
             rfmPaths[capturedPathNumber] = descriptor
             result = expectedCount
             processor = OPRFMGETPATH
@@ -981,11 +1011,12 @@ public class DriveWireHost : Codable {
 
         func OPRFMGETPATH(data: Data) -> Int {
             guard let crOffset = data.firstIndex(of: 0x0D) else { return 0 }
-            let pathname = String(bytes: data[data.startIndex..<crOffset], encoding: .ascii) ?? ""
+            let pathBytes = data[data.startIndex..<crOffset].map { $0 & 0x7F }
+            let pathname = String(bytes: pathBytes, encoding: .ascii) ?? ""
             rfmPaths[capturedPathNumber]?.pathname = pathname
             let errorCode = rfmPaths[capturedPathNumber]?.openLocalFile(rootPath: rfmRootPath) ?? 0xFF
             delegate?.dataAvailable(host: self, data: Data([errorCode]))
-            log += "OP_RFM_OPEN(\(capturedPathNumber), \(pathname)) -> \(errorCode)\n"
+            log += "OP_RFM_\(shouldCreate ? "CREATE" : "OPEN")(\(capturedPathNumber), \(pathname)) -> \(errorCode)\n"
             resetState()
             return crOffset - data.startIndex + 1
         }

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -164,51 +164,25 @@ public class DriveWireHost : Codable {
             return 0
         }
 
-        mutating func readLineFromFile(offset : Int, maximumCount : Int) -> (UInt8, Data) {
-            var errorCode : UInt8 = 0
+        mutating func readLineFromFile(maximumCount: Int) -> (UInt8, Data) {
+            guard filePosition < fileContents.count else { return (211, Data()) }
             var data = Data()
-            
-            var byte : UInt8 = 0
-            repeat {
-                do {
-                    if filePosition >= fileContents.count {
-                        errorCode = 211
-                        break
-                    }
-                    byte = fileContents[filePosition]
-                    filePosition = filePosition + 1
-                    if byte == 0x0A {
-                        byte = 0x0D
-                    }
-                    data = data + Data([byte])
-                } catch {
-                    errorCode = 211
-                }
-            } while filePosition < fileContents.count && data.count <= maximumCount && byte != 0x0D && errorCode == 0
-
-            return (errorCode, data)
+            while filePosition < fileContents.count && data.count < maximumCount {
+                var byte = fileContents[filePosition]
+                filePosition += 1
+                if byte == 0x0A { byte = 0x0D }
+                data.append(byte)
+                if byte == 0x0D { break }
+            }
+            return (0, data)
         }
 
-        mutating func readFromFile(offset : Int, maximumCount : Int) -> (UInt8, Data) {
-            var errorCode : UInt8 = 0
-            var data = Data()
-            
-            var byte : UInt8 = 0
-            repeat {
-                do {
-                    if filePosition >= fileContents.count {
-                        errorCode = 211
-                        break
-                    }
-                    byte = fileContents[filePosition]
-                    filePosition = filePosition + 1
-                    data = data + Data([byte])
-                } catch {
-                    errorCode = 211
-                }
-            } while filePosition < fileContents.count && data.count < maximumCount && errorCode == 0
-
-            return (errorCode, data)
+        mutating func readFromFile(maximumCount: Int) -> (UInt8, Data) {
+            guard filePosition < fileContents.count else { return (211, Data()) }
+            let end = min(filePosition + maximumCount, fileContents.count)
+            let data = Data(fileContents[filePosition..<end])
+            filePosition = end
+            return (0, data)
         }
     }
 
@@ -1068,7 +1042,7 @@ public class DriveWireHost : Codable {
             result = expectedCount
 
             if var descriptor = rfmPaths[pathNumber] {
-                let (errorCode, lineData) = descriptor.readFromFile(offset: descriptor.filePosition, maximumCount: maxBytes)
+                let (errorCode, lineData) = descriptor.readFromFile(maximumCount: maxBytes)
                 rfmPaths[pathNumber] = descriptor
                 if errorCode != 0 {
                     delegate?.dataAvailable(host: self, data: Data([0x00]))
@@ -1117,7 +1091,7 @@ public class DriveWireHost : Codable {
             result = expectedCount
 
             if var descriptor = rfmPaths[pathNumber] {
-                let (errorCode, lineData) = descriptor.readLineFromFile(offset: descriptor.filePosition, maximumCount: maxBytes)
+                let (errorCode, lineData) = descriptor.readLineFromFile(maximumCount: maxBytes)
                 rfmPaths[pathNumber] = descriptor
                 if errorCode != 0 {
                     delegate?.dataAvailable(host: self, data: Data([0x00]))

--- a/swift/DriveWire/Model/DriveWireHost.swift
+++ b/swift/DriveWire/Model/DriveWireHost.swift
@@ -193,6 +193,7 @@ public class DriveWireHost : Codable {
                     ? Data(data.map { $0 == 0x0D ? 0x0A : $0 })
                     : data
                 file.write(bytesToWrite)
+                file.synchronizeFile()
                 // Keep fileContents in sync for subsequent reads
                 let end = filePosition + bytesToWrite.count
                 if fileContents.count < end {

--- a/swift/drivewire-cli/main.swift
+++ b/swift/drivewire-cli/main.swift
@@ -10,7 +10,10 @@ import ArgumentParser
 
 struct DriveWireCmd: ParsableCommand {
     @Option(name: .shortAndLong, help: "Serial port path (e.g. /dev/cu.usbserial-FTVA079L)")
-    var port: String
+    var port: String?
+
+    @Option(name: .long, help: "TCP port to listen on for incoming guest connections (e.g. MAME -bitb socket.127.0.0.1:<port>)")
+    var tcpPort: UInt16?
 
     @Option(name: .shortAndLong, help: "Baud rate for the serial port")
     var baudRate: Int = 57600
@@ -34,29 +37,32 @@ struct DriveWireCmd: ParsableCommand {
     var rfmRoot: String = NSHomeDirectory()
 
     func run() throws {
-        let d = DriveWireSerialDriver()
+        guard port != nil || tcpPort != nil else {
+            throw ValidationError("Provide either --port (serial) or --tcp-port (TCP server).")
+        }
 
-        d.baudRate = baudRate
-        d.portName = port
-        d.logging = verbose
-        d.host.rfmRootPath = rfmRoot
+        func insertDisks(into host: DriveWireHost) throws {
+            if let p = disk0 { try host.insertVirtualDisk(driveNumber: 0, imagePath: p) }
+            if let p = disk1 { try host.insertVirtualDisk(driveNumber: 1, imagePath: p) }
+            if let p = disk2 { try host.insertVirtualDisk(driveNumber: 2, imagePath: p) }
+            if let p = disk3 { try host.insertVirtualDisk(driveNumber: 3, imagePath: p) }
+        }
 
-        if let disk0Path = disk0 {
-            try d.host.insertVirtualDisk(driveNumber: 0, imagePath: disk0Path)
+        if let listenPort = tcpPort {
+            let d = DriveWireTCPServerDriver()
+            d.logging = verbose
+            d.host.rfmRootPath = rfmRoot
+            try insertDisks(into: d.host)
+            try d.start(port: listenPort)
+        } else if let serialPort = port {
+            let d = DriveWireSerialDriver()
+            d.baudRate = baudRate
+            d.portName = serialPort
+            d.logging = verbose
+            d.host.rfmRootPath = rfmRoot
+            try insertDisks(into: d.host)
         }
-        
-        if let disk1Path = disk1 {
-            try d.host.insertVirtualDisk(driveNumber: 1, imagePath: disk1Path)
-        }
-        
-        if let disk2Path = disk2 {
-            try d.host.insertVirtualDisk(driveNumber: 2, imagePath: disk2Path)
-        }
-        
-        if let disk3Path = disk3 {
-            try d.host.insertVirtualDisk(driveNumber: 3, imagePath: disk3Path)
-        }
-        
+
         while true {
             RunLoop.current.run(mode: .default, before: Date.distantFuture)
         }

--- a/swift/drivewire-cli/main.swift
+++ b/swift/drivewire-cli/main.swift
@@ -30,12 +30,16 @@ struct DriveWireCmd: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Show client activity")
     var verbose: Bool = false
 
+    @Option(name: .long, help: "Root path for RFM file access (default: home directory)")
+    var rfmRoot: String = NSHomeDirectory()
+
     func run() throws {
         let d = DriveWireSerialDriver()
-        
+
         d.baudRate = baudRate
         d.portName = port
         d.logging = verbose
+        d.host.rfmRootPath = rfmRoot
 
         if let disk0Path = disk0 {
             try d.host.insertVirtualDisk(driveNumber: 0, imagePath: disk0Path)


### PR DESCRIPTION
## Summary

Full RFM (Remote File Manager) implementation — CoCo 3 NitrOS-9 can now read and write files on the Mac host via the DriveWire Becker port in MAME.

### What works
- `list /y0/file` — read files from host
- `PRINT #1` in Basic09 — write text to host files  
- `mdir>/y0/output` — redirect command output to host files
- Shell `>` redirect for any NitrOS-9 command

### Protocol fixes
- All RFM op handlers match `rfm.asm` wire format (open, read, readln, seek, close, getstat, setstat, write, writeln)
- `rfmPaths` dictionary replaces single descriptor — multiple simultaneous paths work
- `rfmRootPath` (`--rfm-root`) sets the host base directory; `/y0/file` maps to `rfmRootPath/y0/file`

### Write correctness
- Sequential `file.write()` — no seek/position tracking that caused zero-padding corruption  
- CR→LF translation and `$FF` padding strip for OS-9 string buffers
- `shouldCreate` paths survive their first close (OS-9 shell redirect pattern: CREATE→CLOSE→WRITELNs)
- Fallback to open writable descriptor for I$Dup2 path# remapping

### Server crash fixes
- `DriveWireHost.init()` calls `setupTransactions()` so `processor` is never nil
- `start()` no longer discards pre-inserted virtual disks
- Force-unwrap crashes on non-ASCII bytes replaced with safe fallbacks
- Serial channel handlers consume correct byte counts (was causing framing desync → spurious RFM opcodes)
- Watchdog cancelled mid-transaction

### TCP server (`--tcp-port`)
- `DriveWireTCPServerDriver` for MAME's Becker port socket connection
- `drivewire-cli` gains `--tcp-port` and `--rfm-root`

## Test plan
- [x] `list /y0/filename` reads host files
- [x] `PRINT #1,"text"` in Basic09 writes to host files  
- [x] `mdir>/y0/output` redirects mdir output to host file
- [x] NitrOS-9 boots from DriveWire disk via HDB-DOS Becker port in MAME
- [ ] Seek and random-access read/write

🤖 Generated with [Claude Code](https://claude.com/claude-code)